### PR TITLE
feat: Prevent Constant Error Declaration

### DIFF
--- a/docs/rfc/const-error-decl.md
+++ b/docs/rfc/const-error-decl.md
@@ -1,0 +1,97 @@
+# RFC: Constant Error Declaration Rule
+
+## Summary
+
+This rule detects and reports the use of `const` for declaring errors created with `errors.New()`, which is not allowed in Go/Gno.
+
+## Motivation
+
+The result of `errors.New()` is not a constant value, even though the string passed to it is constant. Using `const` for such declarations can lead to compilation errors. This rule helps developers avoid this common mistake and use `var` for error declarations instead.
+
+## Proposed Implementation
+
+The rule will scan all `const` declarations in the code and check if any of them use `errors.New()`. If found, it will report an issue suggesting to use `var` instead.
+
+### Rule Details
+
+- **Rule ID**: const-error-declaration
+- **Severity**: error
+- **Category**: bug prevention
+- **Auto-fixable**: Yes
+
+### Code Examples
+
+#### Incorrect
+
+**Case 1** Single error in a single const declaration
+
+```go
+const err = errors.New("error")
+```
+
+Output
+
+```plain
+error: const-error-declaration
+ --> foo.gno
+  |
+5 | const err = errors.New("error")
+  | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  = Constant declaration of errors.New() is not allowed
+```
+
+**Case 2** Multiple errors in a single const declaration
+
+```go
+const (
+    err1 = errors.New("error1")
+    err2 = errors.New("error2")
+)
+```
+
+Output
+
+```plain
+error: const-error-declaration
+ --> foo.gno
+  |
+5 | const (
+6 |     err1 = errors.New("error")
+7 |     err2 = errors.New("error2")
+8 | )
+  | ~~
+  = Constant declaration of errors.New() is not allowed
+```
+
+#### Correct
+
+**Case 1** Single error in a single var declaration
+
+```go
+var err = errors.New("error")
+```
+
+**Case 2** Multiple errors in a single var declaration
+
+```go
+var (
+    err1 = errors.New("error1")
+    err2 = errors.New("error2")
+)
+```
+
+### Exceptions
+
+There are no exceptions to this rule. All `const` declarations using `errors.New()` should be reported.
+
+## Alternatives
+
+An alternative approach could be to allow `const` declarations of errors but wrap them in a function call that returns an error interface. However, this approach is less idiomatic in Go and may lead to confusion.
+
+## Implementation Impact
+
+Positive impacts:
+
+- Prevents compilation errors
+- Encourages correct usage of error declarations
+- Improves code consistency

--- a/docs/rfc/const-error-decl.md
+++ b/docs/rfc/const-error-decl.md
@@ -2,13 +2,13 @@
 
 ## Summary
 
-This rule detects and reports the use of `const` for declaring errors created with `errors.New()`, which is not allowed in Go/Gno.
+This rule detects and reports the use of `const` for declaring errors created with `errors.New()`. The rule enforces the usage of `var` for error declarations, preventing compilation issues that arise when using `const` for error values.
 
 ## Motivation
 
 The result of `errors.New()` is not a constant value, even though the string passed to it is constant. Using `const` for such declarations can lead to compilation errors. This rule helps developers avoid this common mistake and use `var` for error declarations instead.
 
-## Proposed Implementation
+## Implementation
 
 The rule will scan all `const` declarations in the code and check if any of them use `errors.New()`. If found, it will report an issue suggesting to use `var` instead.
 
@@ -16,7 +16,7 @@ The rule will scan all `const` declarations in the code and check if any of them
 
 - **Rule ID**: const-error-declaration
 - **Severity**: error
-- **Category**: bug prevention
+- **Category**: bug prevention, best practices
 - **Auto-fixable**: Yes
 
 ### Code Examples
@@ -95,3 +95,7 @@ Positive impacts:
 - Prevents compilation errors
 - Encourages correct usage of error declarations
 - Improves code consistency
+
+Negative impacts:
+
+- Potential migration costs could arise

--- a/docs/rfc/template.md
+++ b/docs/rfc/template.md
@@ -21,11 +21,11 @@
 
 ### Code Examples
 
-#### Incorrect:
+#### Incorrect
 
 [Example of code that violates the rule]
 
-#### Correct:
+#### Correct
 
 [Example of code that does not violate the rule]
 

--- a/internal/engine.go
+++ b/internal/engine.go
@@ -51,6 +51,7 @@ var allRuleConstructors = ruleMap{
 	"defer-issues":                NewDeferRule,
 	"gno-mod-tidy":                NewMissingModPackageRule,
 	"slice-bounds-check":          NewSliceBoundCheckRule,
+	"const-error-declaration":     NewConstErrorDeclarationRule,
 }
 
 func (e *Engine) applyRules(rules map[string]tt.ConfigRule) {
@@ -92,6 +93,7 @@ func (e *Engine) registerDefaultRules() {
 	e.rules["useless-break"] = allRuleConstructors["useless-break"]()
 	e.rules["defer-issues"] = allRuleConstructors["defer-issues"]()
 	e.rules["gno-mod-tidy"] = allRuleConstructors["gno-mod-tidy"]()
+	e.rules["const-error-declaration"] = allRuleConstructors["const-error-declaration"]()
 }
 
 func (e *Engine) findRule(name string) LintRule {

--- a/internal/lints/const_error_decl.go
+++ b/internal/lints/const_error_decl.go
@@ -48,6 +48,7 @@ func DetectConstErrorDeclaration(
 				Message:    "Constant declaration of errors.New() is not allowed",
 				Suggestion: "Use var instead of const for error declarations",
 				Confidence: 1.0,
+				Severity:   severity,
 			}
 			issues = append(issues, issue)
 		}

--- a/internal/lints/const_error_decl.go
+++ b/internal/lints/const_error_decl.go
@@ -1,0 +1,78 @@
+package lints
+
+import (
+	"go/ast"
+	"go/token"
+
+	tt "github.com/gnolang/tlin/internal/types"
+)
+
+func DetectConstErrorDeclaration(
+	filename string,
+	node *ast.File,
+	fset *token.FileSet,
+	severity tt.Severity,
+) ([]tt.Issue, error) {
+	var issues []tt.Issue
+
+	ast.Inspect(node, func(n ast.Node) bool {
+		genDecl, ok := n.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.CONST {
+			return true
+		}
+
+		containsErrorsNew := false
+		for _, spec := range genDecl.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+
+			for _, value := range valueSpec.Values {
+				if isErrorNew(value) {
+					containsErrorsNew = true
+					break
+				}
+			}
+			if containsErrorsNew {
+				break
+			}
+		}
+
+		if containsErrorsNew {
+			issue := tt.Issue{
+				Rule:       "const-error-declaration",
+				Filename:   filename,
+				Start:      fset.Position(genDecl.Pos()),
+				End:        fset.Position(genDecl.End()),
+				Message:    "Constant declaration of errors.New() is not allowed",
+				Suggestion: "Use var instead of const for error declarations",
+				Confidence: 1.0,
+			}
+			issues = append(issues, issue)
+		}
+
+		return true
+	})
+
+	return issues, nil
+}
+
+func isErrorNew(expr ast.Expr) bool {
+	callExpr, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+
+	selector, ok := callExpr.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+
+	ident, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+
+	return selector.Sel.Name == "New" && ident.Name == "errors"
+}

--- a/internal/rule_set.go
+++ b/internal/rule_set.go
@@ -339,6 +339,32 @@ func (r *MissingModPackageRule) SetSeverity(severity tt.Severity) {
 	r.severity = severity
 }
 
+type ConstErrorDeclarationRule struct {
+	severity tt.Severity
+}
+
+func NewConstErrorDeclarationRule() LintRule {
+	return &ConstErrorDeclarationRule{
+		severity: tt.SeverityError,
+	}
+}
+
+func (r *ConstErrorDeclarationRule) Check(filename string, node *ast.File, fset *token.FileSet) ([]tt.Issue, error) {
+	return lints.DetectConstErrorDeclaration(filename, node, fset, r.severity)
+}
+
+func (r *ConstErrorDeclarationRule) Name() string {
+	return "const-error-declaration"
+}
+
+func (r *ConstErrorDeclarationRule) SetSeverity(severity tt.Severity) {
+	r.severity = severity
+}
+
+func (r *ConstErrorDeclarationRule) Severity() tt.Severity {
+	return r.severity
+}
+
 // -----------------------------------------------------------------------------
 // Regex related rules
 

--- a/testdata/const-error-decl/const_decl.gno
+++ b/testdata/const-error-decl/const_decl.gno
@@ -1,0 +1,9 @@
+package main
+
+import "errors"
+
+const err = errors.New("error")
+
+func main() {
+	println("foo")
+}

--- a/testdata/const-error-decl/const_decl_multiple.gno
+++ b/testdata/const-error-decl/const_decl_multiple.gno
@@ -1,0 +1,12 @@
+package main
+
+import "errors"
+
+const (
+	err = errors.New("error")
+	err2 = errors.New("error2")
+)
+
+func main() {
+	println("foo")
+}

--- a/testdata/const-error-decl/var_decl.gno
+++ b/testdata/const-error-decl/var_decl.gno
@@ -1,0 +1,9 @@
+package main
+
+import "errors"
+
+var err = errors.New("error")
+
+func main() {
+	println("foo")
+}


### PR DESCRIPTION
# Description

Detect and report the use of `const` for declaring errors created with `errors.New()`.