### PR TITLE
fix: Display line information in `unused-import` checks

### DIFF
--- a/internal/lints/gno_analyzer.go
+++ b/internal/lints/gno_analyzer.go
@@ -92,8 +92,8 @@ func runGnoPackageLinter(_ *ast.File, fset *token.FileSet, deps Dependencies, se
 
 	for imp, dep := range deps {
 		if !dep.IsUsed && !dep.IsIgnored {
-			startPos := fset.Position(token.Pos(dep.Line))
-			endPos := fset.Position(token.Pos(dep.Line))
+			startPos := fset.Position(dep.Line)
+			endPos := fset.Position(dep.Column)
 			issue := tt.Issue{
 				Rule:       "unused-import",
 				Message:    fmt.Sprintf("unused import: %s", imp),

--- a/internal/lints/gno_analyzer.go
+++ b/internal/lints/gno_analyzer.go
@@ -21,17 +21,19 @@ type Dependency struct {
 	IsGno      bool
 	IsUsed     bool
 	IsIgnored  bool // aliased as `_`
+	Line       token.Pos
+	Column     token.Pos
 }
 
 type Dependencies map[string]*Dependency
 
-func DetectGnoPackageImports(filename string, _ *ast.File, _ *token.FileSet, severity tt.Severity) ([]tt.Issue, error) {
+func DetectGnoPackageImports(filename string, _ *ast.File, fset *token.FileSet, severity tt.Severity) ([]tt.Issue, error) {
 	file, deps, err := analyzeFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("error analyzing file: %w", err)
 	}
 
-	issues := runGnoPackageLinter(file, deps, severity)
+	issues := runGnoPackageLinter(file, fset, deps, severity)
 
 	for i := range issues {
 		issues[i].Filename = filename
@@ -60,6 +62,8 @@ func analyzeFile(filename string) (*ast.File, Dependencies, error) {
 			IsGno:      isGnoPackage(impPath),
 			IsUsed:     false,
 			IsIgnored:  imp.Name != nil && imp.Name.Name == "_",
+			Line:       imp.Pos(),
+			Column:     imp.End(),
 		}
 	}
 
@@ -83,15 +87,20 @@ func analyzeFile(filename string) (*ast.File, Dependencies, error) {
 	return file, deps, nil
 }
 
-func runGnoPackageLinter(_ *ast.File, deps Dependencies, severity tt.Severity) []tt.Issue {
+func runGnoPackageLinter(_ *ast.File, fset *token.FileSet, deps Dependencies, severity tt.Severity) []tt.Issue {
 	var issues []tt.Issue
 
-	for impPath, dep := range deps {
+	for imp, dep := range deps {
 		if !dep.IsUsed && !dep.IsIgnored {
+			startPos := fset.Position(token.Pos(dep.Line))
+			endPos := fset.Position(token.Pos(dep.Line))
 			issue := tt.Issue{
-				Rule:     "unused-import",
-				Message:  fmt.Sprintf("unused import: %s", impPath),
-				Severity: severity,
+				Rule:       "unused-import",
+				Message:    fmt.Sprintf("unused import: %s", imp),
+				Severity:   severity,
+				Start:      startPos,
+				End:        endPos,
+				Confidence: 1.0,
 			}
 			issues = append(issues, issue)
 		}

--- a/internal/lints/gno_analyzer_test.go
+++ b/internal/lints/gno_analyzer_test.go
@@ -1,6 +1,7 @@
 package lints
 
 import (
+	"go/token"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -69,11 +70,12 @@ func TestRunLinter(t *testing.T) {
 		tt := tt
 		t.Run(filepath.Base(tt.filename), func(t *testing.T) {
 			t.Parallel()
+			fset := token.NewFileSet()
 			file, deps, err := analyzeFile(tt.filename)
 			require.NoError(t, err)
 			require.NotNil(t, file)
 
-			issues := runGnoPackageLinter(file, deps, types.SeverityError)
+			issues := runGnoPackageLinter(file, fset, deps, types.SeverityError)
 
 			assert.Equal(t, len(tt.expectedIssues), len(issues), "Number of issues doesn't match expected for %s", tt.filename)
 


### PR DESCRIPTION
# Desscription

closes #134 

## Output

```plain
warning: unused-import
 --> testdata/pkg/pkg0.gno:6:5
  |
6 | "strings" // unused import
  | ^
  |
  = unused import: strings
```