### PR TITLE
feat: Detect Deprecated `std` Functions

### DIFF
--- a/internal/lints/deprecate_func.go
+++ b/internal/lints/deprecate_func.go
@@ -12,9 +12,18 @@ import (
 func register() *checker.DeprecatedFuncChecker {
 	deprecated := checker.NewDeprecatedFuncChecker()
 
-	deprecated.Register("std", "SetOrigCaller", "std.PrevRealm")
-	deprecated.Register("std", "GetOrigCaller", "std.PrevRealm")
-	deprecated.Register("std", "TestSetOrigCaller", "")
+	// functions
+	deprecated.Register("std", "GetCallerAt", "std.CallerAt")
+	deprecated.Register("std", "GetOrigSend", "std.OriginSend")
+	deprecated.Register("std", "GetOrigCaller", "std.OriginCaller")
+	deprecated.Register("std", "PrevRealm", "std.PreviousRealm")
+	deprecated.Register("std", "GetChainID", "std.ChainID")
+	deprecated.Register("std", "GetBanker", "std.NewBanker")
+	deprecated.Register("std", "GetChainDomain", "std.ChainDomain")
+	deprecated.Register("std", "GetHeight", "std.Height")
+
+	// chaining methods
+	deprecated.RegisterMethod("std", "Address", "Addr", "Address")
 
 	return deprecated
 }

--- a/internal/rule_set.go
+++ b/internal/rule_set.go
@@ -42,6 +42,7 @@ var (
 	DeferRule                    = LintRule{severity: tt.SeverityWarning, check: lints.DetectDeferIssues}
 	ConstErrorDeclarationRule    = LintRule{severity: tt.SeverityError, check: lints.DetectConstErrorDeclaration}
 	RepeatedRegexCompilationRule = LintRule{severity: tt.SeverityWarning, check: lints.DetectRepeatedRegexCompilation}
+	DeprecatedFuncRule           = LintRule{severity: tt.SeverityError, check: lints.DetectDeprecatedFunctions}
 	GnoSpecificRule              = LintRule{severity: tt.SeverityWarning, check: lints.DetectGnoPackageImports}
 )
 
@@ -60,5 +61,6 @@ var allRules = ruleMap{
 	"defer-issues":                DeferRule,
 	"const-error-declaration":     ConstErrorDeclarationRule,
 	"repeated-regex-compilation":  RepeatedRegexCompilationRule,
+	"deprecated":                  DeprecatedFuncRule,
 	"unused-package":              GnoSpecificRule,
 }


### PR DESCRIPTION
# Description

to support this change https://github.com/gnolang/gno/pull/3374#event-16367327758

## Changes

Added a new data structure `PkgTypeMethodMap` to store deprecated methods by package, type, and method name
Implemented `RegisterMethod` function to register deprecated methods