### PR TITLE
feat: simplify for loop

### DIFF
--- a/internal/lints/simplify_for_range.go
+++ b/internal/lints/simplify_for_range.go
@@ -1,0 +1,185 @@
+package lints
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+
+	tt "github.com/gnolang/tlin/internal/types"
+)
+
+// DetectSimplifiableForLoops detects simplifiable for loops
+//
+// Normally, in go, a for loop is of the form:
+//
+//	for i := 0; i < n; i++ {
+//	    ^^^^^^  ^^^^^  ^^^
+//	      |      |     |
+//	      |      |     +--- increment statement (e.g. i++) (3)
+//	      |      +--- condition statement (e.g. i < n) (2)
+//	      +--- initialize statement (e.g. i := 0) (1)
+//
+// We can simplify this to:
+//
+//	for i := range n {
+//	   ^^^^^^  ^^^^^
+//	     |      |
+//	     |      +--- condition statement (e.g. i < n) (2)
+//	     +--- initialize statement (e.g. i := 0) (1)
+//
+// However, this simplification is not always possible.
+//
+// For example, the following conditions cannot be simplified:
+//
+// 1. When the initialization statement doesn't start from 0
+// 2. When the condition is not a simple comparison with '<'
+// 3. When the increment is not a simple i++
+// 4. When the loop variable is modified inside the loop body
+//
+//	for i := 0; i < n; i++ {
+//	    if condition { i++ } // Skip an iteration
+//	}
+//
+// 5. When n is not a constant or variable (it must be iterable):
+//
+//	for i := 0; i < someFunction(); i++ { ... }
+//
+// 6. When the loop counter is used after the loop:
+//
+//	for i := 0; i < n; i++ { ... }
+//	fmt.Println("Final i:", i) // i is used after the loop
+//
+// 7. When the intent is to iterate over indices, but range iteration needs the values:
+//
+//	for i := 0; i < len(slice); i++ {
+//	    if i > 0 && slice[i] == slice[i-1] { ... } // Needs index access
+//	}
+//
+// 8. When using multiple variables in the loop:
+//
+// 9. When the loop needs to break early with a specific index value:
+//
+//	for i := 0; i < n; i++ {
+//	    if condition { break }
+//	}
+//	// Using the final value of i for something
+func DetectSimplifiableForLoops(filename string, node *ast.File, fset *token.FileSet, severity tt.Severity) ([]tt.Issue, error) {
+	var issues []tt.Issue
+
+	ast.Inspect(node, func(n ast.Node) bool {
+		forStmt, ok := n.(*ast.ForStmt)
+		if !ok {
+			return true
+		}
+
+		init, ok := forStmt.Init.(*ast.AssignStmt)
+		if !ok || init.Tok != token.DEFINE || len(init.Lhs) != 1 || len(init.Rhs) != 1 {
+			return true
+		}
+
+		// (2)
+		cond, ok := forStmt.Cond.(*ast.BinaryExpr)
+		if !ok || cond.Op != token.LSS {
+			return true
+		}
+
+		// (3)
+		post, ok := forStmt.Post.(*ast.IncDecStmt)
+		if !ok || post.Tok != token.INC {
+			return true
+		}
+
+		// check variable name is consistent
+		initIdent, ok := init.Lhs[0].(*ast.Ident)
+		if !ok {
+			return true
+		}
+
+		condLeftIdent, ok := cond.X.(*ast.Ident)
+		if !ok || condLeftIdent.Name != initIdent.Name {
+			return true
+		}
+
+		postIdent, ok := post.X.(*ast.Ident)
+		if !ok || postIdent.Name != initIdent.Name {
+			return true
+		}
+
+		// check initial value is 0
+		initValue, ok := init.Rhs[0].(*ast.BasicLit)
+		if !ok || initValue.Value != "0" {
+			return true
+		}
+
+		// check variable is not modified inside the loop
+		var modifiesLoopVar bool
+		ast.Inspect(forStmt.Body, func(node ast.Node) bool {
+			if assign, ok := node.(*ast.AssignStmt); ok {
+				for _, lhs := range assign.Lhs {
+					if ident, ok := lhs.(*ast.Ident); ok && ident.Name == initIdent.Name {
+						modifiesLoopVar = true
+						return false
+					}
+				}
+			}
+			if incDec, ok := node.(*ast.IncDecStmt); ok {
+				if ident, ok := incDec.X.(*ast.Ident); ok && ident.Name == initIdent.Name {
+					modifiesLoopVar = true
+					return false
+				}
+			}
+			return true
+		})
+		if modifiesLoopVar {
+			return true
+		}
+
+		// check loop range is not a function call
+		if _, ok := cond.Y.(*ast.CallExpr); ok {
+			return true
+		}
+
+		// check loop variable is not used after the loop
+		var usedAfterLoop bool
+		ast.Inspect(node, func(n ast.Node) bool {
+			if n == forStmt {
+				return false // skip loop body
+			}
+			if ident, ok := n.(*ast.Ident); ok && ident.Name == initIdent.Name {
+				usedAfterLoop = true
+				return false
+			}
+			return true
+		})
+		if usedAfterLoop {
+			return true
+		}
+
+		condRightIdent := cond.Y
+		bodyStr := tt.Node2String(forStmt.Body)
+
+		suggestion := fmt.Sprintf("for %s := range %s %s",
+			initIdent.Name,
+			tt.Node2String(condRightIdent),
+			bodyStr,
+		)
+
+		pos := fset.Position(forStmt.Pos())
+		end := fset.Position(forStmt.End())
+
+		issues = append(issues, tt.Issue{
+			Rule:       "simplify_for_range",
+			Message:    "counter-based for loop can be simplified to range-based loop",
+			Category:   "style",
+			Start:      pos,
+			End:        end,
+			Severity:   severity,
+			Suggestion: suggestion,
+			Confidence: 0.9,
+		})
+
+		return true
+	})
+
+	return issues, nil
+}

--- a/internal/lints/simplify_for_range_test.go
+++ b/internal/lints/simplify_for_range_test.go
@@ -1,0 +1,112 @@
+package lints
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+
+	tt "github.com/gnolang/tlin/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimplifyForRange(t *testing.T) {
+	tests := []struct {
+		name      string
+		code      string
+		wantIssue bool
+	}{
+		{
+			name: "trivial for loop",
+			code: `
+package main
+
+func main() {
+	for i := 0; i < 5; i++ {
+		println(i)
+	}
+}`,
+			wantIssue: true,
+		},
+		{
+			name: "already using range",
+			code: `
+package main
+
+func main() {
+	for i := range 5 {
+		println(i)
+	}
+}`,
+			wantIssue: false,
+		},
+		{
+			name: "different form of for loop",
+			code: `
+package main
+
+func main() {
+	for i := 0; i <= 5; i += 2 {
+		println(i)
+	}
+}`,
+			wantIssue: false,
+		},
+		{
+			name: "variable has been modified inside the loop",
+			code: `
+package main
+
+func main() {
+	for i := 0; i < 5; i++ {
+		if i > 3 {
+			i++
+		}
+		println(i)
+	}
+}`,
+			wantIssue: false,
+		},
+		{
+			name: "initial value is not 0",
+			code: `
+package main
+
+func main() {
+	for i := 1; i < 5; i++ {
+		println(i)
+	}
+}`,
+			wantIssue: false,
+		},
+		{
+			name: "multiple variables",
+			code: `
+package main
+
+func main() {
+	for i, j := 0, 5; i < j; i, j = i+1, j-1 {
+		println(i, j)
+	}
+}`,
+			wantIssue: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "test.go", test.code, parser.ParseComments)
+			require.NoError(t, err)
+
+			issues, err := DetectSimplifiableForLoops("test.go", file, fset, tt.SeverityWarning)
+			require.NoError(t, err)
+
+			if test.wantIssue {
+				require.Len(t, issues, 1)
+				require.Equal(t, "counter-based for loop can be simplified to range-based loop", issues[0].Message)
+			} else {
+				require.Empty(t, issues)
+			}
+		})
+	}
+}

--- a/internal/rule_set.go
+++ b/internal/rule_set.go
@@ -44,6 +44,7 @@ var (
 	RepeatedRegexCompilationRule = LintRule{severity: tt.SeverityWarning, check: lints.DetectRepeatedRegexCompilation}
 	DeprecatedFuncRule           = LintRule{severity: tt.SeverityError, check: lints.DetectDeprecatedFunctions}
 	GnoSpecificRule              = LintRule{severity: tt.SeverityWarning, check: lints.DetectGnoPackageImports}
+	SimplifyForRangeRule         = LintRule{severity: tt.SeverityWarning, check: lints.DetectSimplifiableForLoops}
 )
 
 // Define the ruleMap type
@@ -63,4 +64,5 @@ var allRules = ruleMap{
 	"repeated-regex-compilation":  RepeatedRegexCompilationRule,
 	"deprecated":                  DeprecatedFuncRule,
 	"unused-package":              GnoSpecificRule,
+	"simplify-for-range":          SimplifyForRangeRule,
 }

--- a/internal/types/analyzer.go
+++ b/internal/types/analyzer.go
@@ -1,0 +1,45 @@
+package types
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// TODO: keep for the future
+
+// RunAnalyzer runs the analyzer for the given code and returns the issues
+func RunAnalyzer(code string, analyzer *analysis.Analyzer) ([]Issue, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "test.go", code, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	var issues []Issue
+	pass := &analysis.Pass{
+		Fset:  fset,
+		Files: []*ast.File{file},
+		Report: func(d analysis.Diagnostic) {
+			pos := fset.Position(d.Pos)
+			end := fset.Position(d.End)
+
+			issues = append(issues, Issue{
+				Rule:     analyzer.Name,
+				Message:  d.Message,
+				Category: d.Category,
+				Start:    pos,
+				End:      end,
+			})
+		},
+	}
+
+	_, err = analyzer.Run(pass)
+	if err != nil {
+		return nil, err
+	}
+
+	return issues, nil
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,9 +1,12 @@
 package types
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"go/ast"
+	"go/printer"
 	"go/token"
 )
 
@@ -125,6 +128,13 @@ func (s *Severity) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // Rule represents an individual rule with an ID and severity.
 type ConfigRule struct {
-	Severity Severity    `yaml:"severity"`
-	Data     interface{} `yaml:"data"` // Data can be anything
+	Severity Severity `yaml:"severity"`
+	Data     any      `yaml:"data"` // Data can be anything
+}
+
+// NodeToString converts an AST node to its string representation
+func Node2String(node ast.Node) string {
+	var buf bytes.Buffer
+	printer.Fprint(&buf, token.NewFileSet(), node)
+	return buf.String()
 }

--- a/testdata/simple_for/for0.gno
+++ b/testdata/simple_for/for0.gno
@@ -1,0 +1,7 @@
+package main
+
+func main() {
+	for i := 0; i < 5; i++ {
+		println(i)
+	}
+}

--- a/testdata/simple_for/for1.gno
+++ b/testdata/simple_for/for1.gno
@@ -1,0 +1,9 @@
+package main
+
+const N = 5
+
+func main() {
+	for i := 0; i < N; i++ {
+		println(i)
+	}
+}

--- a/testdata/simple_for/for2.gno
+++ b/testdata/simple_for/for2.gno
@@ -1,0 +1,11 @@
+package main
+
+func Range() int {
+	return 5
+}
+
+func main() {
+	for i := 0; i < Range(); i++ {
+		println(i)
+	}
+}

--- a/testdata/simple_for/for3.gno
+++ b/testdata/simple_for/for3.gno
@@ -1,0 +1,7 @@
+package main
+
+func main() {
+	for i := range 100 {
+		println(i)
+	}
+}

--- a/testdata/simple_for/for4.gno
+++ b/testdata/simple_for/for4.gno
@@ -1,0 +1,10 @@
+package main
+
+func main() {
+	for i := 0; i < n; i++ {
+		if i > 3 {
+			i++
+		}
+		println(i)
+	}
+}

--- a/testdata/simple_for/for5.gno
+++ b/testdata/simple_for/for5.gno
@@ -1,0 +1,7 @@
+package main
+
+func main() {
+	for i := 1; i < 5; i++ {
+		println(i)
+	}
+}

--- a/testdata/simple_for/for6.gno
+++ b/testdata/simple_for/for6.gno
@@ -1,0 +1,7 @@
+package main
+
+func main() {
+	for i, j := 0, 5; i < j; i, j = i+1, j-1 {
+		println(i, j)
+	}
+}


### PR DESCRIPTION
# Description

Added a new lint rule that detects counter-based for loops that can be simplified to range-based loops.

The rule analyzes for loops and suggests simplifying them from:
```go
for i := 0; i < n; i++ {
    // body
}
```
to:
```go
for i := range n {
    // body  
}
```

The analyzer performs the following checks:

1. Validates loop structure:
   - Initialize statement must be `i := 0`
   - Condition must be `i < n` (less than operator)
   - Post statement must be `i++`
   - Variable names must be consistent across all parts

2. Additional safety checks:
   - Loop variable must not be modified inside the loop body
   - Loop range must not be a function call (must be iterable)
   - Loop variable must not be used after the loop
   - Initial value must be 0

## Example

Input:
```go
for i := 0; i < 5; i++ {
    println(i)
}
```

Output suggestion:
```go
for i := range 5 {
    println(i)
}
```