### PR TITLE
fix: Update Slice Expression Simplifier

### DIFF
--- a/internal/lints/gno_analyzer.go
+++ b/internal/lints/gno_analyzer.go
@@ -61,7 +61,7 @@ func analyzeFile(filename string) (*ast.File, Dependencies, error) {
 			ImportPath: impPath,
 			IsGno:      isGnoPackage(impPath),
 			IsUsed:     false,
-			IsIgnored:  imp.Name != nil && imp.Name.Name == "_",
+			IsIgnored:  imp.Name != nil && imp.Name.Name == blankIdentifier,
 			Line:       imp.Pos(),
 			Column:     imp.End(),
 		}

--- a/internal/lints/simplify_slice_expr.go
+++ b/internal/lints/simplify_slice_expr.go
@@ -8,57 +8,111 @@ import (
 	tt "github.com/gnolang/tlin/internal/types"
 )
 
+const (
+	baseMessageUnnecessaryLen = "unnecessary use of len() in slice expression, can be simplified"
+	ruleName                  = "simplify-slice-range"
+
+	msgTemplateNoIndex = "%s\nin this case, `%s[:len(%s)]` is equivalent to `%s[:]`. " +
+		"the full length of the slice is already implied when omitting both start and end indices."
+
+	msgTemplateWithLiteral = "%s\nhere, `%s[%s:len(%s)]` can be simplified to `%s[%s:]`. " +
+		"when slicing to the end of a slice, using len() is unnecessary."
+
+	msgTemplateWithIdent = "%s\nin this instance, `%s[%s:len(%s)]` can be written as `%s[%s:]`. " +
+		"the len() function is redundant when slicing to the end, regardless of the start index."
+)
+
+// DetectUnnecessarySliceLength detects unnecessary len() calls in slice expressions.
+// Example: a[:len(a)] -> a[:]
 func DetectUnnecessarySliceLength(filename string, node *ast.File, fset *token.FileSet, severity tt.Severity) ([]tt.Issue, error) {
 	var issues []tt.Issue
+
 	ast.Inspect(node, func(n ast.Node) bool {
 		sliceExpr, ok := n.(*ast.SliceExpr)
 		if !ok {
 			return true
 		}
 
-		if callExpr, ok := sliceExpr.High.(*ast.CallExpr); ok {
-			if ident, ok := callExpr.Fun.(*ast.Ident); ok && ident.Name == "len" {
-				if arg, ok := callExpr.Args[0].(*ast.Ident); ok {
-					if sliceExpr.X.(*ast.Ident).Name == arg.Name {
-						var suggestion, detailedMessage string
-						baseMessage := "unnecessary use of len() in slice expression, can be simplified"
-
-						if sliceExpr.Low == nil {
-							suggestion = fmt.Sprintf("%s[:]", arg.Name)
-							detailedMessage = fmt.Sprintf(
-								"%s\nin this case, `%s[:len(%s)]` is equivalent to `%s[:]`. "+
-									"the full length of the slice is already implied when omitting both start and end indices.",
-								baseMessage, arg.Name, arg.Name, arg.Name)
-						} else if basicLit, ok := sliceExpr.Low.(*ast.BasicLit); ok {
-							suggestion = fmt.Sprintf("%s[%s:]", arg.Name, basicLit.Value)
-							detailedMessage = fmt.Sprintf("%s\nhere, `%s[%s:len(%s)]` can be simplified to `%s[%s:]`. "+
-								"when slicing to the end of a slice, using len() is unnecessary.",
-								baseMessage, arg.Name, basicLit.Value, arg.Name, arg.Name, basicLit.Value)
-						} else if lowIdent, ok := sliceExpr.Low.(*ast.Ident); ok {
-							suggestion = fmt.Sprintf("%s[%s:]", arg.Name, lowIdent.Name)
-							detailedMessage = fmt.Sprintf("%s\nin this instance, `%s[%s:len(%s)]` can be written as `%s[%s:]`. "+
-								"the len() function is redundant when slicing to the end, regardless of the start index.",
-								baseMessage, arg.Name, lowIdent.Name, arg.Name, arg.Name, lowIdent.Name)
-						}
-
-						issue := tt.Issue{
-							Rule:       "simplify-slice-range",
-							Filename:   filename,
-							Start:      fset.Position(sliceExpr.Pos()),
-							End:        fset.Position(sliceExpr.End()),
-							Message:    baseMessage,
-							Suggestion: suggestion,
-							Note:       detailedMessage,
-							Severity:   severity,
-						}
-						issues = append(issues, issue)
-					}
-				}
-			}
+		if issue, found := checkUnnecessaryLenInSliceExpr(sliceExpr, filename, fset, severity); found {
+			issues = append(issues, issue)
 		}
 
 		return true
 	})
 
 	return issues, nil
+}
+
+// checkUnnecessaryLenInSliceExpr checks a slice expression for unnecessary len() calls.
+func checkUnnecessaryLenInSliceExpr(sliceExpr *ast.SliceExpr, filename string, fset *token.FileSet, severity tt.Severity) (tt.Issue, bool) {
+	// skip 3-index slices as they always require the 2nd and 3rd index
+	if sliceExpr.Max != nil {
+		return tt.Issue{}, false
+	}
+
+	// check if the array/slice object is a single identifier
+	sliceIdent, ok := sliceExpr.X.(*ast.Ident)
+	if !ok || sliceIdent.Obj == nil {
+		return tt.Issue{}, false
+	}
+
+	// check if the high expression is a function call with a single argument
+	call, ok := sliceExpr.High.(*ast.CallExpr)
+	if !ok || !isValidLenCall(call) {
+		return tt.Issue{}, false
+	}
+
+	// check if the function is "len" and not locally defined
+	lenIdent, ok := call.Fun.(*ast.Ident)
+	if !ok || lenIdent.Name != "len" || lenIdent.Obj != nil {
+		return tt.Issue{}, false
+	}
+
+	// check if the len argument is the same as the array/slice object
+	arg, ok := call.Args[0].(*ast.Ident)
+	if !ok || arg.Obj != sliceIdent.Obj {
+		return tt.Issue{}, false
+	}
+
+	suggestion, detailedMessage := createSuggestionAndMessage(sliceExpr, sliceIdent)
+
+	return tt.Issue{
+		Rule:       ruleName,
+		Filename:   filename,
+		Start:      fset.Position(sliceExpr.Pos()),
+		End:        fset.Position(sliceExpr.End()),
+		Message:    baseMessageUnnecessaryLen,
+		Suggestion: suggestion,
+		Note:       detailedMessage,
+		Severity:   severity,
+	}, true
+}
+
+// isValidLenCall checks if a function call is a valid len() call.
+func isValidLenCall(call *ast.CallExpr) bool {
+	return len(call.Args) == 1 && !call.Ellipsis.IsValid()
+}
+
+// createSuggestionAndMessage creates the suggestion and detailed message for the issue.
+func createSuggestionAndMessage(sliceExpr *ast.SliceExpr, sliceIdent *ast.Ident) (string, string) {
+	var suggestion, detailedMessage string
+
+	if sliceExpr.Low == nil {
+		suggestion = fmt.Sprintf("%s[:]", sliceIdent.Name)
+		detailedMessage = fmt.Sprintf(
+			msgTemplateNoIndex,
+			baseMessageUnnecessaryLen, sliceIdent.Name, sliceIdent.Name, sliceIdent.Name)
+	} else if basicLit, ok := sliceExpr.Low.(*ast.BasicLit); ok {
+		suggestion = fmt.Sprintf("%s[%s:]", sliceIdent.Name, basicLit.Value)
+		detailedMessage = fmt.Sprintf(
+			msgTemplateWithLiteral,
+			baseMessageUnnecessaryLen, sliceIdent.Name, basicLit.Value, sliceIdent.Name, sliceIdent.Name, basicLit.Value)
+	} else if lowIdent, ok := sliceExpr.Low.(*ast.Ident); ok {
+		suggestion = fmt.Sprintf("%s[%s:]", sliceIdent.Name, lowIdent.Name)
+		detailedMessage = fmt.Sprintf(
+			msgTemplateWithIdent,
+			baseMessageUnnecessaryLen, sliceIdent.Name, lowIdent.Name, sliceIdent.Name, sliceIdent.Name, lowIdent.Name)
+	}
+
+	return suggestion, detailedMessage
 }

--- a/internal/lints/simplify_slice_expr.go
+++ b/internal/lints/simplify_slice_expr.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"strings"
 
 	tt "github.com/gnolang/tlin/internal/types"
 )
@@ -28,52 +29,106 @@ func DetectUnnecessarySliceLength(filename string, node *ast.File, fset *token.F
 	var issues []tt.Issue
 
 	ast.Inspect(node, func(n ast.Node) bool {
-		sliceExpr, ok := n.(*ast.SliceExpr)
-		if !ok {
-			return true
+		switch stmt := n.(type) {
+		case *ast.AssignStmt:
+			issues = append(issues, processAssignStmt(stmt, filename, fset, severity)...)
+		case *ast.ValueSpec:
+			// XXX: I'm not sure about we need to process this case.
+			issues = append(issues, processValueSpec(stmt, filename, fset, severity)...)
 		}
-
-		if issue, found := checkUnnecessaryLenInSliceExpr(sliceExpr, filename, fset, severity); found {
-			issues = append(issues, issue)
-		}
-
 		return true
 	})
 
 	return issues, nil
 }
 
+// processAssignStmt processes assignment statements to find unnecessary len() calls.
+func processAssignStmt(stmt *ast.AssignStmt, filename string, fset *token.FileSet, severity tt.Severity) []tt.Issue {
+	var issues []tt.Issue
+
+	for i, rhs := range stmt.Rhs {
+		sliceExpr, ok := rhs.(*ast.SliceExpr)
+		if !ok {
+			continue
+		}
+
+		issue, found := checkUnnecessaryLenInSliceExpr(sliceExpr, filename, fset, severity)
+		if !found {
+			continue
+		}
+
+		// Only process if there's a corresponding left-hand side
+		if i < len(stmt.Lhs) {
+			lhs, ok := stmt.Lhs[i].(*ast.Ident)
+			if ok {
+				issue.Suggestion = formatSuggestion(lhs.Name, getOperator(lhs.Name, stmt.Tok), issue.Suggestion)
+			}
+		}
+
+		issues = append(issues, issue)
+	}
+
+	return issues
+}
+
+// processValueSpec processes variable declarations to find unnecessary len() calls.
+func processValueSpec(stmt *ast.ValueSpec, filename string, fset *token.FileSet, severity tt.Severity) []tt.Issue {
+	var issues []tt.Issue
+
+	for i, value := range stmt.Values {
+		sliceExpr, ok := value.(*ast.SliceExpr)
+		if !ok {
+			continue
+		}
+
+		issue, found := checkUnnecessaryLenInSliceExpr(sliceExpr, filename, fset, severity)
+		if !found {
+			continue
+		}
+
+		// Only process if there's a corresponding name
+		if i < len(stmt.Names) {
+			name := stmt.Names[i].Name
+			issue.Suggestion = formatSuggestion(name, getOperator(name, token.DEFINE), issue.Suggestion)
+		}
+
+		issues = append(issues, issue)
+	}
+
+	return issues
+}
+
+// getOperator returns the appropriate operator based on the identifier and token.
+func getOperator(identName string, tok token.Token) string {
+	// blank identifier always uses assignment operator
+	if identName == blankIdentifier {
+		return opAssign
+	}
+
+	if tok == token.DEFINE {
+		return opDefine
+	}
+
+	return opAssign
+}
+
+// formatSuggestion formats the suggestion string with the variable name and operator.
+func formatSuggestion(name string, operator string, suggestion string) string {
+	return fmt.Sprintf("%s %s %s", name, operator, suggestion)
+}
+
 // checkUnnecessaryLenInSliceExpr checks a slice expression for unnecessary len() calls.
 func checkUnnecessaryLenInSliceExpr(sliceExpr *ast.SliceExpr, filename string, fset *token.FileSet, severity tt.Severity) (tt.Issue, bool) {
-	// skip 3-index slices as they always require the 2nd and 3rd index
+	// Skip 3-index slices as they always require the 2nd and 3rd index
 	if sliceExpr.Max != nil {
 		return tt.Issue{}, false
 	}
 
-	// check if the array/slice object is a single identifier
-	sliceIdent, ok := sliceExpr.X.(*ast.Ident)
-	if !ok || sliceIdent.Obj == nil {
+	if !isSliceWithLenCall(sliceExpr) {
 		return tt.Issue{}, false
 	}
 
-	// check if the high expression is a function call with a single argument
-	call, ok := sliceExpr.High.(*ast.CallExpr)
-	if !ok || !isValidLenCall(call) {
-		return tt.Issue{}, false
-	}
-
-	// check if the function is "len" and not locally defined
-	lenIdent, ok := call.Fun.(*ast.Ident)
-	if !ok || lenIdent.Name != "len" || lenIdent.Obj != nil {
-		return tt.Issue{}, false
-	}
-
-	// check if the len argument is the same as the array/slice object
-	arg, ok := call.Args[0].(*ast.Ident)
-	if !ok || arg.Obj != sliceIdent.Obj {
-		return tt.Issue{}, false
-	}
-
+	sliceIdent := sliceExpr.X.(*ast.Ident)
 	suggestion, detailedMessage := createSuggestionAndMessage(sliceExpr, sliceIdent)
 
 	return tt.Issue{
@@ -86,6 +141,35 @@ func checkUnnecessaryLenInSliceExpr(sliceExpr *ast.SliceExpr, filename string, f
 		Note:       detailedMessage,
 		Severity:   severity,
 	}, true
+}
+
+// isSliceWithLenCall checks if the slice expression has unnecessary len() call.
+func isSliceWithLenCall(sliceExpr *ast.SliceExpr) bool {
+	// check if the array/slice object is a single identifier
+	sliceIdent, ok := sliceExpr.X.(*ast.Ident)
+	if !ok || sliceIdent.Obj == nil {
+		return false
+	}
+
+	// check if the high expression is a function call with a single argument
+	call, ok := sliceExpr.High.(*ast.CallExpr)
+	if !ok || !isValidLenCall(call) {
+		return false
+	}
+
+	// check if the function is "len" and not locally defined
+	lenIdent, ok := call.Fun.(*ast.Ident)
+	if !ok || lenIdent.Name != "len" || lenIdent.Obj != nil {
+		return false
+	}
+
+	// check if the len argument is the same as the array/slice object
+	arg, ok := call.Args[0].(*ast.Ident)
+	if !ok || arg.Obj != sliceIdent.Obj {
+		return false
+	}
+
+	return true
 }
 
 // isValidLenCall checks if a function call is a valid len() call.
@@ -112,7 +196,40 @@ func createSuggestionAndMessage(sliceExpr *ast.SliceExpr, sliceIdent *ast.Ident)
 		detailedMessage = fmt.Sprintf(
 			msgTemplateWithIdent,
 			baseMessageUnnecessaryLen, sliceIdent.Name, lowIdent.Name, sliceIdent.Name, sliceIdent.Name, lowIdent.Name)
+	} else if binaryExpr, ok := sliceExpr.Low.(*ast.BinaryExpr); ok {
+		// Handle BinaryExpr type of Low index
+		start := fmt.Sprintf("%s[%s:", sliceIdent.Name, formatBinaryExpr(binaryExpr))
+		suggestion = start + "]"
+		detailedMessage = fmt.Sprintf(
+			msgTemplateWithIdent,
+			baseMessageUnnecessaryLen, sliceIdent.Name, formatBinaryExpr(binaryExpr), sliceIdent.Name, sliceIdent.Name, formatBinaryExpr(binaryExpr))
 	}
 
 	return suggestion, detailedMessage
+}
+
+// formatBinaryExpr converts BinaryExpr to a string.
+func formatBinaryExpr(expr *ast.BinaryExpr) string {
+	left := formatExpr(expr.X)
+	right := formatExpr(expr.Y)
+	return fmt.Sprintf("%s %s %s", left, expr.Op, right)
+}
+
+// formatExpr converts Expr to a string.
+func formatExpr(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.BasicLit:
+		return e.Value
+	case *ast.CallExpr:
+		if ident, ok := e.Fun.(*ast.Ident); ok {
+			args := make([]string, len(e.Args))
+			for i, arg := range e.Args {
+				args[i] = formatExpr(arg)
+			}
+			return fmt.Sprintf("%s(%s)", ident.Name, strings.Join(args, ", "))
+		}
+	}
+	return ""
 }

--- a/internal/lints/simplify_slice_expr.go
+++ b/internal/lints/simplify_slice_expr.go
@@ -44,7 +44,7 @@ func DetectUnnecessarySliceLength(filename string, node *ast.File, fset *token.F
 
 // processAssignStmt processes assignment statements to find unnecessary len() calls.
 func processAssignStmt(stmt *ast.AssignStmt, filename string, fset *token.FileSet, severity tt.Severity) []tt.Issue {
-	var issues []tt.Issue
+	issues := make([]tt.Issue, 0, len(stmt.Rhs))
 
 	for i, rhs := range stmt.Rhs {
 		sliceExpr, ok := rhs.(*ast.SliceExpr)
@@ -73,7 +73,7 @@ func processAssignStmt(stmt *ast.AssignStmt, filename string, fset *token.FileSe
 
 // processValueSpec processes variable declarations to find unnecessary len() calls.
 func processValueSpec(stmt *ast.ValueSpec, filename string, fset *token.FileSet, severity tt.Severity) []tt.Issue {
-	var issues []tt.Issue
+	issues := make([]tt.Issue, 0, len(stmt.Values))
 
 	for i, value := range stmt.Values {
 		sliceExpr, ok := value.(*ast.SliceExpr)
@@ -86,7 +86,7 @@ func processValueSpec(stmt *ast.ValueSpec, filename string, fset *token.FileSet,
 			continue
 		}
 
-		// Only process if there's a corresponding name
+		// only process if there's a corresponding name
 		if i < len(stmt.Names) {
 			name := stmt.Names[i].Name
 			issue.Suggestion = formatSuggestion(name, getOperator(name, token.DEFINE), issue.Suggestion)
@@ -119,7 +119,7 @@ func formatSuggestion(name string, operator string, suggestion string) string {
 
 // checkUnnecessaryLenInSliceExpr checks a slice expression for unnecessary len() calls.
 func checkUnnecessaryLenInSliceExpr(sliceExpr *ast.SliceExpr, filename string, fset *token.FileSet, severity tt.Severity) (tt.Issue, bool) {
-	// Skip 3-index slices as they always require the 2nd and 3rd index
+	// skip 3-index slices as they always require the 2nd and 3rd index
 	if sliceExpr.Max != nil {
 		return tt.Issue{}, false
 	}

--- a/internal/lints/tokens.go
+++ b/internal/lints/tokens.go
@@ -1,0 +1,8 @@
+package lints
+
+const (
+	blankIdentifier = "_"
+
+	opAssign = "="
+	opDefine = ":="
+)

--- a/testdata/slice1.gno
+++ b/testdata/slice1.gno
@@ -1,0 +1,70 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testdata
+
+var (
+	a [10]byte
+	b [20]float32
+	s []int
+	t struct {
+		s []byte
+	}
+
+	_ = a[0:]
+	_ = a[1:10]
+	_ = a[2:len(a)] // want "unneeded: len\\(a\\)"
+	_ = a[3:(len(a))]
+	_ = a[len(a)-1 : len(a)] // want "unneeded: len\\(a\\)"
+	_ = a[2:len(a):len(a)]
+
+	_ = a[:]
+	_ = a[:10]
+	_ = a[:len(a)] // want "unneeded: len\\(a\\)"
+	_ = a[:(len(a))]
+	_ = a[:len(a)-1]
+	_ = a[:len(a):len(a)]
+
+	_ = s[0:]
+	_ = s[1:10]
+	_ = s[2:len(s)] // want "unneeded: len\\(s\\)"
+	_ = s[3:(len(s))]
+	_ = s[len(a) : len(s)-1]
+	_ = s[0:len(b)]
+	_ = s[2:len(s):len(s)]
+
+	_ = s[:]
+	_ = s[:10]
+	_ = s[:len(s)] // want "unneeded: len\\(s\\)"
+	_ = s[:(len(s))]
+	_ = s[:len(s)-1]
+	_ = s[:len(b)]
+	_ = s[:len(s):len(s)]
+
+	_ = t.s[0:]
+	_ = t.s[1:10]
+	_ = t.s[2:len(t.s)]
+	_ = t.s[3:(len(t.s))]
+	_ = t.s[len(a) : len(t.s)-1]
+	_ = t.s[0:len(b)]
+	_ = t.s[2:len(t.s):len(t.s)]
+
+	_ = t.s[:]
+	_ = t.s[:10]
+	_ = t.s[:len(t.s)]
+	_ = t.s[:(len(t.s))]
+	_ = t.s[:len(t.s)-1]
+	_ = t.s[:len(b)]
+	_ = t.s[:len(t.s):len(t.s)]
+)
+
+func _() {
+	s := s[0:len(s)] // want "unneeded: len\\(s\\)"
+	_ = s
+}
+
+func m() {
+	maps := []int{}
+	_ = maps[1:len(maps)] // want "unneeded: len\\(maps\\)"
+}


### PR DESCRIPTION
# Description

Update a lint rule that detects and suggests simplifications for unnecessary `len()` usage in slice expressions. The implementation is based on the Go standard library's `simplifyslice` analyzer, but adapted to work within our linting framework.

## Key Changes from Previous Version
1. **Enhanced Type Checking**
   - Added explicit checks for 3-index slices (`s[low:high:max]`)
   - Improved validation of slice expressions to ensure they're valid for simplification
   - Added checks for locally defined `len` functions to avoid false positives

2. **Improved Error Detection**
   - More comprehensive validation of slice expression components
   - Better handling of edge cases and invalid expressions
   - Clearer separation of different simplification scenarios

3. **Fixed Suggestion Formatting**
   - Corrected operator handling in suggestions to properly respect the original code's syntax
   - Added special handling for blank identifiers (`_`) to always use assignment operator (`=`) as required by Go syntax
   - Ensured suggestions maintain the complete expression format (left-hand side, operator, right-hand side) for clear and accurate code replacement