### PR TITLE
feat: heuristic verifier framework for lint rewrites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 # Go workspace file
 go.work
 go.work.sum
+
+.gocache

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,167 @@
+# TODO Plan for Implementing and Validating MiniLogic v2.1
+
+This TODO list is organized into implementation phases by increasing semantic complexity. Each phase includes concrete implementation tasks and a corresponding test suite to verify correctness. This plan reflects the v2.1 formal specification and focuses on safe early-return validation.
+
+---
+
+## Priority Fixes (Spec Alignment)
+
+### P0: OpaqueCalls must preserve call order for expression calls
+
+* [x] Track `CallExpr` evaluations in expressions (not just `CallStmt`) so `OpaqueCalls` enforces ordering and multiplicity across all calls.
+  * Must guarantee: call sequences include expression-level calls in evaluation order.
+  * Must guarantee: equivalence fails when expression call order differs or calls are duplicated/dropped.
+  * Recommendation: centralize call capture in `EvalExpr` and return both value+calls, or thread call logs through expression evaluation.
+
+### P1: Allow calls in early-return conditions under OpaqueCalls
+
+* [x] Allow `cond` to contain calls as long as call order and multiplicity are preserved.
+  * Must guarantee: call order and multiplicity are identical between original and rewritten forms.
+  * Must guarantee: `panic(...)` is treated as a call and therefore participates in call-order checks.
+  * Recommendation: rely on OpaqueCalls call-sequence equality for safety.
+
+### P1: Support `var` declarations in if-init (or reject explicitly)
+
+* [x] Extend AST conversion and evaluator to support `var` in `if init; cond {}` or explicitly mark as out-of-scope with a clear reason.
+  * Must guarantee: `var` in `if init` is either modeled (scoped) or yields `Unknown` with a specific reason.
+  * Must guarantee: scope cleanup preserves outer variables and hides init-scoped identifiers.
+  * Recommendation: add a `VarDeclStmt` node and handle it alongside `DeclAssignStmt`.
+
+### P2: Ensure Unknown stays Unknown in lint gate fallback
+
+* [x] In `verifyWithMiniLogic`, avoid treating `Unknown` as verified-safe solely via structural normalization/flattening.
+  * Must guarantee: rewrites outside scope remain `Unknown` and do not auto-apply.
+  * Must guarantee: fallback normalization does not override an explicit `Unknown`.
+  * Recommendation: only use structural fallback when both sides are already within scope and the evaluator did not return `Unknown`.
+
+## Phase 1: Core Evaluation Engine (No Termination Handling)
+
+### Implementation Tasks
+
+* [x] Define AST and internal IR for minimal statements: assignment, sequencing, if-else
+* [x] Define symbolic environment model (`Env`) as key-value map
+* [x] Implement evaluator for:
+
+  * [x] `x = e`
+  * [x] `S1 ; S2`
+  * [x] `if cond { S1 } else { S2 }`
+* [x] Encode semantics for `eval(e, Env)`
+* [x] Define base `Result = Continue(Env)` only
+* [x] Implement basic statement equivalence: equality of `Env` outputs
+
+### Tests
+
+* [x] Unit: `x = 1` vs. `x = 1`
+* [x] Unit: `x = 1; y = 2` vs. `x = 1; y = 2`
+* [x] Negative: `x = 1` vs. `x = 2`
+* [x] If-else equivalence: constant true/false branches
+* [ ] Property-based: permutation invariance under `Env` equality
+
+---
+
+## Phase 2: Add Termination-Aware Result Types and Semantics
+
+### Implementation Tasks
+
+* [x] Extend `Result` with: `Return(Value?)`, `Break`, `ContinueLoop`
+* [x] Implement short-circuit sequencing: stop on non-`Continue`
+* [x] Extend statement evaluator with:
+
+  * [x] `return e?`
+  * [x] `break`
+  * [x] `continue`
+* [x] Update equivalence logic to compare `Result` values (with termination kind)
+
+### Tests
+
+* [x] Unit: `return 1` vs. `return 1`
+* [x] Unit: `if cond { return 1 } else { return 2 }` vs. same
+* [x] Negative: `return 1` vs. `return 2`
+* [x] Sequencing: `return 1; x = 2` == `return 1`
+* [x] Mismatch type: `return 1` vs. `x = 1`
+
+---
+
+## Phase 3: Control-Flow Normalization & Early-Return Equivalence
+
+### Implementation Tasks
+
+* [x] Normalize rewrites: flattening `if { return } else { S }` into `if { return }; S`
+* [x] Add canonical pattern equivalence engine
+* [x] Implement constraint check: all `if` branches must terminate
+* [x] Handle pure condition check assumption (assumed for now)
+
+### Tests
+
+* [x] Rewrite: `if cond { return } else { x = 1 }` vs. `if cond { return }; x = 1`
+* [x] Nested return: `if cond { if sub { return } else { x = 1 } }` equivalence
+* [x] Incomplete rewrite: one branch missing `return` → not equivalent
+
+---
+
+## Phase 4: Scoped Initializer Support (`if init; cond {}`)
+
+### Implementation Tasks
+
+* [x] Parse and represent `init` expressions in conditional statements
+* [x] Restrict scope of init-bound identifiers to branch only
+* [x] Detect illegal reference to scoped `init` variable in later statements
+* [x] Mark such rewrites as `Unknown`
+
+### Tests
+
+* [x] Equivalence: `if x := f(); cond { return } else { return }` == same
+* [x] Scope violation: `if x := f(); cond { return } else { x = 1 }; x = 2` → `Unknown`
+* [x] Shadowing: init var does not affect outer scope
+
+---
+
+## Phase 5: Function Call Policy (Opaque vs. Disallowed)
+
+### Implementation Tasks
+
+* [x] Add support for `call(...)` statements
+* [x] Add `CallPolicy = OpaqueCalls | DisallowCalls`
+* [x] Under `OpaqueCalls`, track call order and count
+* [x] Reject equivalence if calls are reordered or duplicated
+* [x] Under `DisallowCalls`, reject any call-containing block as `Unknown`
+
+### Tests
+
+* [x] Equivalence with same calls in order: pass under `OpaqueCalls`
+* [x] Call in one branch only: fail equivalence
+* [x] Disallowed calls: any presence → `Unknown`
+* [x] Panic as call: does not terminate unless explicitly modeled
+
+---
+
+## Phase 6: Error Reporting, SMT Hook, and Edge Case Handling
+
+### Implementation Tasks
+
+* [x] Surface `Unknown` status with reason code
+* [x] Hook SMT solver or symbolic engine for `eval(cond, Env)`
+* [x] Encode equivalence conditions as `ite` terms
+* [x] Add logging and debugging output per statement pair
+
+### Tests
+
+* [x] Log trace: successful proof vs. unknown vs. mismatch
+* [x] Regression: verify known safe and unsafe early-return rewrites
+* [x] Stress: long sequence of nested early-return blocks
+
+---
+
+## Optional Phase 7: Fuzzing and Soundness Checks
+
+### Implementation Tasks
+
+* [ ] Fuzz original vs. randomly permuted rewrite variants
+* [ ] Use property-based testing to confirm: `equivalent → same output`
+* [ ] Use mutation testing to confirm: `non-equivalent → detected`
+
+### Tests
+
+* [ ] Fuzz over all valid rewrites under `OpaqueCalls`
+* [ ] Ensure no false positives: mutated programs fail equivalence
+* [ ] Catch scope violations, reorderings, incorrect termination

--- a/internal/lints/early_return.go
+++ b/internal/lints/early_return.go
@@ -153,6 +153,9 @@ func processQualifiedChain(chain *ifChain, ctx *traversalContext) {
 	if err != nil {
 		return
 	}
+	if !verifyWithMiniLogic(snippet, suggestion) {
+		return
+	}
 
 	issue := tt.Issue{
 		Rule:       "early-return",

--- a/internal/lints/minilogic_gate.go
+++ b/internal/lints/minilogic_gate.go
@@ -1,0 +1,389 @@
+package lints
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"strconv"
+
+	"github.com/gnolang/tlin/internal/minilogic"
+)
+
+func verifyWithMiniLogic(original, suggestion string) bool {
+	origStmt, ok := minilogicStmtFromSnippet(original)
+	if !ok {
+		return false
+	}
+	transStmt, ok := minilogicStmtFromSnippet(suggestion)
+	if !ok {
+		return false
+	}
+
+	ml := minilogic.New()
+	report := ml.Verify(origStmt, transStmt)
+	if report.Result == minilogic.Equivalent {
+		return true
+	}
+	if report.Result == minilogic.NotEquivalent {
+		return false
+	}
+
+	normOrig := ml.Normalize(origStmt)
+	normTrans := ml.Normalize(transStmt)
+	flatOrig := flattenAllIfElseChains(normOrig)
+	flatTrans := flattenAllIfElseChains(normTrans)
+	return reflect.DeepEqual(flatOrig, flatTrans)
+}
+
+func minilogicStmtFromSnippet(snippet string) (minilogic.Stmt, bool) {
+	fset := token.NewFileSet()
+	src := "package p\nfunc _() {\n" + snippet + "\n}"
+	file, err := parser.ParseFile(fset, "", src, 0)
+	if err != nil {
+		return nil, false
+	}
+
+	var block *ast.BlockStmt
+	ast.Inspect(file, func(n ast.Node) bool {
+		if fd, ok := n.(*ast.FuncDecl); ok {
+			block = fd.Body
+			return false
+		}
+		return true
+	})
+	if block == nil {
+		return nil, false
+	}
+
+	return astBlockToMini(block)
+}
+
+func astBlockToMini(block *ast.BlockStmt) (minilogic.Stmt, bool) {
+	stmts := make([]minilogic.Stmt, 0, len(block.List))
+	for _, stmt := range block.List {
+		mStmt, ok := astStmtToMini(stmt)
+		if !ok {
+			return nil, false
+		}
+		stmts = append(stmts, mStmt)
+	}
+	return minilogic.Seq(stmts...), true
+}
+
+func astStmtToMini(stmt ast.Stmt) (minilogic.Stmt, bool) {
+	switch s := stmt.(type) {
+	case *ast.BlockStmt:
+		return astBlockToMini(s)
+	case *ast.IfStmt:
+		return astIfToMini(s)
+	case *ast.ReturnStmt:
+		return astReturnToMini(s)
+	case *ast.AssignStmt:
+		return astAssignToMini(s)
+	case *ast.ExprStmt:
+		return astExprStmtToMini(s)
+	case *ast.EmptyStmt:
+		return minilogic.NoopStmt{}, true
+	default:
+		return nil, false
+	}
+}
+
+func astIfToMini(stmt *ast.IfStmt) (minilogic.Stmt, bool) {
+	if stmt.Init != nil {
+		return nil, false
+	}
+	cond, ok := astExprToMini(stmt.Cond)
+	if !ok {
+		return nil, false
+	}
+	thenStmt, ok := astBlockToMini(stmt.Body)
+	if !ok {
+		return nil, false
+	}
+
+	var elseStmt minilogic.Stmt
+	if stmt.Else != nil {
+		var ok bool
+		elseStmt, ok = astStmtToMini(stmt.Else)
+		if !ok {
+			return nil, false
+		}
+	}
+
+	return minilogic.If(cond, thenStmt, elseStmt), true
+}
+
+func astReturnToMini(stmt *ast.ReturnStmt) (minilogic.Stmt, bool) {
+	if len(stmt.Results) == 0 {
+		return nil, false
+	}
+	if len(stmt.Results) > 1 {
+		return nil, false
+	}
+	val, ok := astExprToMini(stmt.Results[0])
+	if !ok {
+		return nil, false
+	}
+	return minilogic.Return(val), true
+}
+
+func astAssignToMini(stmt *ast.AssignStmt) (minilogic.Stmt, bool) {
+	if len(stmt.Lhs) != 1 || len(stmt.Rhs) != 1 {
+		return nil, false
+	}
+	ident, ok := stmt.Lhs[0].(*ast.Ident)
+	if !ok {
+		return nil, false
+	}
+	expr, ok := astExprToMini(stmt.Rhs[0])
+	if !ok {
+		return nil, false
+	}
+
+	switch stmt.Tok {
+	case token.ASSIGN:
+		return minilogic.Assign(ident.Name, expr), true
+	case token.DEFINE:
+		return minilogic.DeclAssign(ident.Name, expr), true
+	default:
+		return nil, false
+	}
+}
+
+func astExprStmtToMini(stmt *ast.ExprStmt) (minilogic.Stmt, bool) {
+	call, ok := stmt.X.(*ast.CallExpr)
+	if !ok {
+		return nil, false
+	}
+
+	funcName, ok := callFuncName(call.Fun)
+	if !ok {
+		return nil, false
+	}
+
+	args := make([]minilogic.Expr, len(call.Args))
+	for i, arg := range call.Args {
+		converted, ok := astExprToMini(arg)
+		if !ok {
+			return nil, false
+		}
+		args[i] = converted
+	}
+
+	return minilogic.Call(funcName, args...), true
+}
+
+func astExprToMini(expr ast.Expr) (minilogic.Expr, bool) {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		switch e.Kind {
+		case token.INT:
+			val, err := strconv.ParseInt(e.Value, 0, 64)
+			if err != nil {
+				return nil, false
+			}
+			return minilogic.IntLit(val), true
+		case token.STRING:
+			val, err := strconv.Unquote(e.Value)
+			if err != nil {
+				return nil, false
+			}
+			return minilogic.StrLit(val), true
+		default:
+			return nil, false
+		}
+	case *ast.Ident:
+		switch e.Name {
+		case "true":
+			return minilogic.BoolLit(true), true
+		case "false":
+			return minilogic.BoolLit(false), true
+		case "nil":
+			return minilogic.NilLit(), true
+		default:
+			return minilogic.Var(e.Name), true
+		}
+	case *ast.BinaryExpr:
+		left, ok := astExprToMini(e.X)
+		if !ok {
+			return nil, false
+		}
+		right, ok := astExprToMini(e.Y)
+		if !ok {
+			return nil, false
+		}
+		op, ok := tokenToBinaryOp(e.Op)
+		if !ok {
+			return nil, false
+		}
+		return minilogic.Binary(op, left, right), true
+	case *ast.UnaryExpr:
+		operand, ok := astExprToMini(e.X)
+		if !ok {
+			return nil, false
+		}
+		op, ok := tokenToUnaryOp(e.Op)
+		if !ok {
+			return nil, false
+		}
+		return minilogic.Unary(op, operand), true
+	case *ast.ParenExpr:
+		return astExprToMini(e.X)
+	case *ast.CallExpr:
+		funcName, ok := callFuncName(e.Fun)
+		if !ok {
+			return nil, false
+		}
+		args := make([]minilogic.Expr, len(e.Args))
+		for i, arg := range e.Args {
+			converted, ok := astExprToMini(arg)
+			if !ok {
+				return nil, false
+			}
+			args[i] = converted
+		}
+		return minilogic.CallExpr{Func: funcName, Args: args}, true
+	default:
+		return nil, false
+	}
+}
+
+func callFuncName(expr ast.Expr) (string, bool) {
+	switch fn := expr.(type) {
+	case *ast.Ident:
+		return fn.Name, true
+	case *ast.SelectorExpr:
+		if ident, ok := fn.X.(*ast.Ident); ok {
+			return ident.Name + "." + fn.Sel.Name, true
+		}
+	}
+	return "", false
+}
+
+func tokenToBinaryOp(tok token.Token) (minilogic.BinaryOp, bool) {
+	switch tok {
+	case token.ADD:
+		return minilogic.OpAdd, true
+	case token.SUB:
+		return minilogic.OpSub, true
+	case token.MUL:
+		return minilogic.OpMul, true
+	case token.QUO:
+		return minilogic.OpDiv, true
+	case token.REM:
+		return minilogic.OpMod, true
+	case token.EQL:
+		return minilogic.OpEq, true
+	case token.NEQ:
+		return minilogic.OpNeq, true
+	case token.LSS:
+		return minilogic.OpLt, true
+	case token.LEQ:
+		return minilogic.OpLte, true
+	case token.GTR:
+		return minilogic.OpGt, true
+	case token.GEQ:
+		return minilogic.OpGte, true
+	case token.LAND:
+		return minilogic.OpAnd, true
+	case token.LOR:
+		return minilogic.OpOr, true
+	default:
+		return 0, false
+	}
+}
+
+func tokenToUnaryOp(tok token.Token) (minilogic.UnaryOp, bool) {
+	switch tok {
+	case token.NOT:
+		return minilogic.OpNot, true
+	case token.SUB:
+		return minilogic.OpNeg, true
+	default:
+		return 0, false
+	}
+}
+
+func flattenAllIfElseChains(stmt minilogic.Stmt) minilogic.Stmt {
+	switch s := stmt.(type) {
+	case minilogic.SeqStmt:
+		first := flattenAllIfElseChains(s.First)
+		second := flattenAllIfElseChains(s.Second)
+		return minilogic.Seq(first, second)
+	case minilogic.BlockStmt:
+		stmts := make([]minilogic.Stmt, 0, len(s.Stmts))
+		for _, st := range s.Stmts {
+			stmts = append(stmts, flattenAllIfElseChains(st))
+		}
+		return minilogic.Block(stmts...)
+	case minilogic.IfStmt:
+		thenStmt := flattenAllIfElseChains(s.Then)
+		var elseStmt minilogic.Stmt
+		if s.Else != nil {
+			elseStmt = flattenAllIfElseChains(s.Else)
+		}
+		s.Then = thenStmt
+		s.Else = elseStmt
+		return flattenMiniLogicIfChain(s)
+	default:
+		return stmt
+	}
+}
+
+func flattenMiniLogicIfChain(ifStmt minilogic.IfStmt) minilogic.Stmt {
+	if !branchTerminates(ifStmt.Then) {
+		return ifStmt
+	}
+
+	result := []minilogic.Stmt{minilogic.IfStmt{
+		Init: ifStmt.Init,
+		Cond: ifStmt.Cond,
+		Then: ifStmt.Then,
+		Else: nil,
+	}}
+
+	current := ifStmt.Else
+	for current != nil {
+		if nested, ok := current.(minilogic.IfStmt); ok {
+			if branchTerminates(nested.Then) {
+				result = append(result, minilogic.IfStmt{
+					Init: nested.Init,
+					Cond: nested.Cond,
+					Then: nested.Then,
+					Else: nil,
+				})
+				current = nested.Else
+				continue
+			}
+		}
+		result = append(result, current)
+		break
+	}
+
+	return minilogic.Seq(result...)
+}
+
+func branchTerminates(stmt minilogic.Stmt) bool {
+	switch s := stmt.(type) {
+	case minilogic.ReturnStmt, minilogic.BreakStmt, minilogic.ContinueStmt:
+		return true
+	case minilogic.BlockStmt:
+		if len(s.Stmts) == 0 {
+			return false
+		}
+		return branchTerminates(s.Stmts[len(s.Stmts)-1])
+	case minilogic.SeqStmt:
+		if branchTerminates(s.First) {
+			return true
+		}
+		return branchTerminates(s.Second)
+	case minilogic.IfStmt:
+		thenTerms := branchTerminates(s.Then)
+		elseTerms := s.Else != nil && branchTerminates(s.Else)
+		return thenTerms && elseTerms
+	default:
+		return false
+	}
+}

--- a/internal/minilogic/api.go
+++ b/internal/minilogic/api.go
@@ -1,0 +1,225 @@
+package minilogic
+
+import "fmt"
+
+// MiniLogic is the main entry point for the verification framework.
+// It provides a high-level API for verifying lint rule transformations.
+type MiniLogic struct {
+	verifier   *Verifier
+	normalizer *Normalizer
+	config     EvalConfig
+}
+
+// New creates a new MiniLogic instance with default configuration.
+func New() *MiniLogic {
+	config := DefaultConfig()
+	return &MiniLogic{
+		verifier:   NewVerifier(config),
+		normalizer: NewNormalizer(config),
+		config:     config,
+	}
+}
+
+// NewWithConfig creates a new MiniLogic instance with the given configuration.
+func NewWithConfig(config EvalConfig) *MiniLogic {
+	return &MiniLogic{
+		verifier:   NewVerifier(config),
+		normalizer: NewNormalizer(config),
+		config:     config,
+	}
+}
+
+// NewForLoopContext creates a MiniLogic instance for verifying
+// transformations inside loop bodies.
+func NewForLoopContext() *MiniLogic {
+	config := EvalConfig{
+		CallPolicy:      OpaqueCalls,
+		ControlFlowMode: EarlyReturnAware,
+		InLoopContext:   true,
+	}
+	return NewWithConfig(config)
+}
+
+// Verify checks if two statements are semantically equivalent.
+func (m *MiniLogic) Verify(original, transformed Stmt) VerificationReport {
+	return m.verifier.CheckEquivalence(original, transformed)
+}
+
+// VerifyWithEnv checks equivalence given an initial environment.
+func (m *MiniLogic) VerifyWithEnv(original, transformed Stmt, env *Env) VerificationReport {
+	return m.verifier.CheckEquivalenceWithEnv(original, transformed, env)
+}
+
+// VerifyNormalized normalizes both statements before checking equivalence.
+// This can help detect equivalence between syntactically different but
+// semantically identical statements.
+func (m *MiniLogic) VerifyNormalized(original, transformed Stmt) VerificationReport {
+	normOrig := m.normalizer.Normalize(original)
+	normTrans := m.normalizer.Normalize(transformed)
+	return m.verifier.CheckEquivalence(normOrig, normTrans)
+}
+
+// VerifyEarlyReturn verifies an early-return transformation.
+//
+// Original:
+//
+//	if cond { return v } else { S }
+//
+// Transformed:
+//
+//	if cond { return v }; S
+func (m *MiniLogic) VerifyEarlyReturn(cond Expr, returnVal Expr, elseStmt Stmt) VerificationReport {
+	return m.verifier.VerifyEarlyReturnRewrite(cond, returnVal, elseStmt)
+}
+
+// VerifyIfElseChainFlattening verifies if-else chain flattening.
+//
+// Original:
+//
+//	if c1 { return v1 } else if c2 { return v2 } else { return v3 }
+//
+// Transformed:
+//
+//	if c1 { return v1 }; if c2 { return v2 }; return v3
+func (m *MiniLogic) VerifyIfElseChainFlattening(conditions []Expr, returns []Expr, fallback Expr) VerificationReport {
+	return m.verifier.VerifyIfElseChainFlattening(conditions, returns, fallback)
+}
+
+// Normalize transforms a statement into its canonical form.
+func (m *MiniLogic) Normalize(stmt Stmt) Stmt {
+	return m.normalizer.Normalize(stmt)
+}
+
+// FlattenIfElseChain flattens a nested if-else chain.
+func (m *MiniLogic) FlattenIfElseChain(stmt Stmt) Stmt {
+	return m.normalizer.FlattenIfElseChain(stmt)
+}
+
+// UnflattenToIfElseChain converts a flat sequence to nested if-else.
+func (m *MiniLogic) UnflattenToIfElseChain(stmt Stmt) Stmt {
+	return m.normalizer.UnflattenToIfElseChain(stmt)
+}
+
+// Evaluate evaluates a statement and returns the result.
+func (m *MiniLogic) Evaluate(stmt Stmt, env *Env) Result {
+	ev := NewEvaluator(m.config)
+	return ev.EvalStmt(stmt, env)
+}
+
+// EvaluateExpr evaluates an expression and returns the value.
+func (m *MiniLogic) EvaluateExpr(expr Expr, env *Env) Value {
+	ev := NewEvaluator(m.config)
+	return ev.EvalExpr(expr, env)
+}
+
+// TransformationContext provides information about a transformation for verification.
+type TransformationContext struct {
+	Original    Stmt
+	Transformed Stmt
+	RuleName    string
+	Location    string // file:line information
+}
+
+// BatchVerify verifies multiple transformations and returns a summary.
+func (m *MiniLogic) BatchVerify(transformations []TransformationContext) BatchVerificationReport {
+	report := BatchVerificationReport{
+		Total:         len(transformations),
+		Equivalent:    0,
+		NotEquivalent: 0,
+		Unknown:       0,
+		Results:       make([]TransformationResult, len(transformations)),
+	}
+
+	for i, t := range transformations {
+		vr := m.Verify(t.Original, t.Transformed)
+		report.Results[i] = TransformationResult{
+			Context: t,
+			Report:  vr,
+		}
+
+		switch vr.Result {
+		case Equivalent:
+			report.Equivalent++
+		case NotEquivalent:
+			report.NotEquivalent++
+		case Unknown:
+			report.Unknown++
+		}
+	}
+
+	return report
+}
+
+// TransformationResult holds the result of verifying a single transformation.
+type TransformationResult struct {
+	Context TransformationContext
+	Report  VerificationReport
+}
+
+// BatchVerificationReport summarizes the results of batch verification.
+type BatchVerificationReport struct {
+	Total         int
+	Equivalent    int
+	NotEquivalent int
+	Unknown       int
+	Results       []TransformationResult
+}
+
+// Summary returns a human-readable summary of the batch verification.
+func (r BatchVerificationReport) Summary() string {
+	return fmt.Sprintf(
+		"Verified %d transformations: %d equivalent, %d not equivalent, %d unknown",
+		r.Total, r.Equivalent, r.NotEquivalent, r.Unknown,
+	)
+}
+
+// SafeTransformations returns only the verified-safe transformations.
+func (r BatchVerificationReport) SafeTransformations() []TransformationResult {
+	safe := make([]TransformationResult, 0)
+	for _, res := range r.Results {
+		if res.Report.Result == Equivalent {
+			safe = append(safe, res)
+		}
+	}
+	return safe
+}
+
+// UnsafeTransformations returns the transformations that failed verification.
+func (r BatchVerificationReport) UnsafeTransformations() []TransformationResult {
+	unsafe := make([]TransformationResult, 0)
+	for _, res := range r.Results {
+		if res.Report.Result == NotEquivalent {
+			unsafe = append(unsafe, res)
+		}
+	}
+	return unsafe
+}
+
+// UnknownTransformations returns transformations with unknown equivalence.
+func (r BatchVerificationReport) UnknownTransformations() []TransformationResult {
+	unknown := make([]TransformationResult, 0)
+	for _, res := range r.Results {
+		if res.Report.Result == Unknown {
+			unknown = append(unknown, res)
+		}
+	}
+	return unknown
+}
+
+// IsSafeToApply determines if a transformation can be safely auto-applied.
+// Returns true only if the transformation is verified as equivalent.
+func IsSafeToApply(report VerificationReport) bool {
+	return report.Result == Equivalent
+}
+
+// ShouldWarn determines if a warning should be emitted for a transformation.
+// Returns true for Unknown results (cannot verify safety).
+func ShouldWarn(report VerificationReport) bool {
+	return report.Result == Unknown
+}
+
+// IsDefinitelyUnsafe determines if a transformation is definitely incorrect.
+// Returns true for NotEquivalent results.
+func IsDefinitelyUnsafe(report VerificationReport) bool {
+	return report.Result == NotEquivalent
+}

--- a/internal/minilogic/api.go
+++ b/internal/minilogic/api.go
@@ -22,6 +22,9 @@ func New() *MiniLogic {
 
 // NewWithConfig creates a new MiniLogic instance with the given configuration.
 func NewWithConfig(config EvalConfig) *MiniLogic {
+	if config.CondSolver == nil {
+		config.CondSolver = BasicCondSolver{}
+	}
 	return &MiniLogic{
 		verifier:   NewVerifier(config),
 		normalizer: NewNormalizer(config),
@@ -32,11 +35,8 @@ func NewWithConfig(config EvalConfig) *MiniLogic {
 // NewForLoopContext creates a MiniLogic instance for verifying
 // transformations inside loop bodies.
 func NewForLoopContext() *MiniLogic {
-	config := EvalConfig{
-		CallPolicy:      OpaqueCalls,
-		ControlFlowMode: EarlyReturnAware,
-		InLoopContext:   true,
-	}
+	config := DefaultConfig()
+	config.InLoopContext = true
 	return NewWithConfig(config)
 }
 

--- a/internal/minilogic/ast.go
+++ b/internal/minilogic/ast.go
@@ -1,6 +1,7 @@
 package minilogic
 
 // Expr represents an expression in the MiniLogic system.
+// This is a small subset of Go expressions, used for lint rewrite checks.
 type Expr interface {
 	isExpr()
 	String() string
@@ -142,6 +143,7 @@ func (e CallExpr) String() string {
 }
 
 // Stmt represents a statement in the MiniLogic system.
+// This is a deliberately small subset of Go statements.
 type Stmt interface {
 	isStmt()
 	String() string

--- a/internal/minilogic/ast.go
+++ b/internal/minilogic/ast.go
@@ -95,7 +95,8 @@ func (e BinaryExpr) String() string {
 type UnaryOp int
 
 const (
-	OpNot UnaryOp = iota
+	_ UnaryOp = iota
+	OpNot
 	OpNeg
 )
 
@@ -167,6 +168,40 @@ type DeclAssignStmt struct {
 func (DeclAssignStmt) isStmt() {}
 func (s DeclAssignStmt) String() string {
 	return s.Var + " := " + s.Expr.String()
+}
+
+// DeclAssignMultiStmt represents a short variable declaration: x, y := e
+// Used primarily in if-init statements with multiple bindings.
+type DeclAssignMultiStmt struct {
+	Vars []string
+	Expr Expr
+}
+
+func (DeclAssignMultiStmt) isStmt() {}
+func (s DeclAssignMultiStmt) String() string {
+	result := ""
+	for i, name := range s.Vars {
+		if i > 0 {
+			result += ", "
+		}
+		result += name
+	}
+	return result + " := " + s.Expr.String()
+}
+
+// VarDeclStmt represents a var declaration: var x = e (or var x).
+// Used primarily in if-init statements.
+type VarDeclStmt struct {
+	Var  string
+	Expr Expr // can be nil for uninitialized declarations
+}
+
+func (VarDeclStmt) isStmt() {}
+func (s VarDeclStmt) String() string {
+	if s.Expr == nil {
+		return "var " + s.Var
+	}
+	return "var " + s.Var + " = " + s.Expr.String()
 }
 
 // SeqStmt represents a sequence of statements: S1 ; S2
@@ -309,6 +344,16 @@ func Assign(v string, e Expr) Stmt {
 // DeclAssign creates a short variable declaration.
 func DeclAssign(v string, e Expr) Stmt {
 	return DeclAssignStmt{Var: v, Expr: e}
+}
+
+// DeclAssignMulti creates a short variable declaration with multiple bindings.
+func DeclAssignMulti(vars []string, e Expr) Stmt {
+	return DeclAssignMultiStmt{Vars: vars, Expr: e}
+}
+
+// VarDecl creates a var declaration.
+func VarDecl(v string, e Expr) Stmt {
+	return VarDeclStmt{Var: v, Expr: e}
 }
 
 // Seq creates a sequence of statements.

--- a/internal/minilogic/ast.go
+++ b/internal/minilogic/ast.go
@@ -30,7 +30,8 @@ func (e VarExpr) String() string {
 type BinaryOp int
 
 const (
-	OpAdd BinaryOp = iota
+	_ BinaryOp = iota
+	OpAdd
 	OpSub
 	OpMul
 	OpDiv

--- a/internal/minilogic/ast.go
+++ b/internal/minilogic/ast.go
@@ -1,0 +1,401 @@
+package minilogic
+
+// Expr represents an expression in the MiniLogic system.
+type Expr interface {
+	isExpr()
+	String() string
+}
+
+// LiteralExpr represents a literal value (int, bool, string, nil).
+type LiteralExpr struct {
+	Val Value
+}
+
+func (LiteralExpr) isExpr() {}
+func (e LiteralExpr) String() string {
+	return e.Val.String()
+}
+
+// VarExpr represents a variable reference.
+type VarExpr struct {
+	Name string
+}
+
+func (VarExpr) isExpr() {}
+func (e VarExpr) String() string {
+	return e.Name
+}
+
+// BinaryOp represents binary operators.
+type BinaryOp int
+
+const (
+	OpAdd BinaryOp = iota
+	OpSub
+	OpMul
+	OpDiv
+	OpMod
+	OpEq
+	OpNeq
+	OpLt
+	OpLte
+	OpGt
+	OpGte
+	OpAnd
+	OpOr
+)
+
+func (op BinaryOp) String() string {
+	switch op {
+	case OpAdd:
+		return "+"
+	case OpSub:
+		return "-"
+	case OpMul:
+		return "*"
+	case OpDiv:
+		return "/"
+	case OpMod:
+		return "%"
+	case OpEq:
+		return "=="
+	case OpNeq:
+		return "!="
+	case OpLt:
+		return "<"
+	case OpLte:
+		return "<="
+	case OpGt:
+		return ">"
+	case OpGte:
+		return ">="
+	case OpAnd:
+		return "&&"
+	case OpOr:
+		return "||"
+	default:
+		return "?"
+	}
+}
+
+// BinaryExpr represents a binary expression.
+type BinaryExpr struct {
+	Op    BinaryOp
+	Left  Expr
+	Right Expr
+}
+
+func (BinaryExpr) isExpr() {}
+func (e BinaryExpr) String() string {
+	return "(" + e.Left.String() + " " + e.Op.String() + " " + e.Right.String() + ")"
+}
+
+// UnaryOp represents unary operators.
+type UnaryOp int
+
+const (
+	OpNot UnaryOp = iota
+	OpNeg
+)
+
+func (op UnaryOp) String() string {
+	switch op {
+	case OpNot:
+		return "!"
+	case OpNeg:
+		return "-"
+	default:
+		return "?"
+	}
+}
+
+// UnaryExpr represents a unary expression.
+type UnaryExpr struct {
+	Op      UnaryOp
+	Operand Expr
+}
+
+func (UnaryExpr) isExpr() {}
+func (e UnaryExpr) String() string {
+	return "(" + e.Op.String() + e.Operand.String() + ")"
+}
+
+// CallExpr represents a function call expression.
+// Function calls are treated as opaque and may have side effects.
+type CallExpr struct {
+	Func string
+	Args []Expr
+}
+
+func (CallExpr) isExpr() {}
+func (e CallExpr) String() string {
+	result := e.Func + "("
+	for i, arg := range e.Args {
+		if i > 0 {
+			result += ", "
+		}
+		result += arg.String()
+	}
+	return result + ")"
+}
+
+// Stmt represents a statement in the MiniLogic system.
+type Stmt interface {
+	isStmt()
+	String() string
+}
+
+// AssignStmt represents an assignment statement: x = e
+type AssignStmt struct {
+	Var  string
+	Expr Expr
+}
+
+func (AssignStmt) isStmt() {}
+func (s AssignStmt) String() string {
+	return s.Var + " = " + s.Expr.String()
+}
+
+// DeclAssignStmt represents a short variable declaration: x := e
+// Used primarily in if-init statements.
+type DeclAssignStmt struct {
+	Var  string
+	Expr Expr
+}
+
+func (DeclAssignStmt) isStmt() {}
+func (s DeclAssignStmt) String() string {
+	return s.Var + " := " + s.Expr.String()
+}
+
+// SeqStmt represents a sequence of statements: S1 ; S2
+type SeqStmt struct {
+	First  Stmt
+	Second Stmt
+}
+
+func (SeqStmt) isStmt() {}
+func (s SeqStmt) String() string {
+	return s.First.String() + "; " + s.Second.String()
+}
+
+// IfStmt represents a conditional statement: if [init]; cond { then } else { els }
+type IfStmt struct {
+	Init Stmt // optional initializer (can be nil)
+	Cond Expr
+	Then Stmt
+	Else Stmt // can be nil for if without else
+}
+
+func (IfStmt) isStmt() {}
+func (s IfStmt) String() string {
+	result := "if "
+	if s.Init != nil {
+		result += s.Init.String() + "; "
+	}
+	result += s.Cond.String() + " { " + s.Then.String() + " }"
+	if s.Else != nil {
+		result += " else { " + s.Else.String() + " }"
+	}
+	return result
+}
+
+// ReturnStmt represents a return statement: return e?
+type ReturnStmt struct {
+	Value Expr // can be nil for bare return
+}
+
+func (ReturnStmt) isStmt() {}
+func (s ReturnStmt) String() string {
+	if s.Value == nil {
+		return "return"
+	}
+	return "return " + s.Value.String()
+}
+
+// BreakStmt represents a break statement.
+type BreakStmt struct{}
+
+func (BreakStmt) isStmt() {}
+func (BreakStmt) String() string {
+	return "break"
+}
+
+// ContinueStmt represents a continue statement.
+type ContinueStmt struct{}
+
+func (ContinueStmt) isStmt() {}
+func (ContinueStmt) String() string {
+	return "continue"
+}
+
+// CallStmt represents a function call statement: call(...)
+// Used for opaque side-effecting calls.
+type CallStmt struct {
+	Call *CallExpr
+}
+
+func (CallStmt) isStmt() {}
+func (s CallStmt) String() string {
+	return s.Call.String()
+}
+
+// BlockStmt represents a block of statements.
+type BlockStmt struct {
+	Stmts []Stmt
+}
+
+func (BlockStmt) isStmt() {}
+func (s BlockStmt) String() string {
+	if len(s.Stmts) == 0 {
+		return "{}"
+	}
+	result := "{ "
+	for i, stmt := range s.Stmts {
+		if i > 0 {
+			result += "; "
+		}
+		result += stmt.String()
+	}
+	return result + " }"
+}
+
+// NoopStmt represents an empty/no-op statement.
+type NoopStmt struct{}
+
+func (NoopStmt) isStmt() {}
+func (NoopStmt) String() string {
+	return "noop"
+}
+
+// Helper functions to construct AST nodes
+
+// Lit creates a literal expression from a value.
+func Lit(v Value) Expr {
+	return LiteralExpr{Val: v}
+}
+
+// IntLit creates an integer literal expression.
+func IntLit(v int64) Expr {
+	return LiteralExpr{Val: IntValue{Val: v}}
+}
+
+// BoolLit creates a boolean literal expression.
+func BoolLit(v bool) Expr {
+	return LiteralExpr{Val: BoolValue{Val: v}}
+}
+
+// StrLit creates a string literal expression.
+func StrLit(v string) Expr {
+	return LiteralExpr{Val: StringValue{Val: v}}
+}
+
+// NilLit creates a nil literal expression.
+func NilLit() Expr {
+	return LiteralExpr{Val: NilValue{}}
+}
+
+// Var creates a variable reference expression.
+func Var(name string) Expr {
+	return VarExpr{Name: name}
+}
+
+// Assign creates an assignment statement.
+func Assign(v string, e Expr) Stmt {
+	return AssignStmt{Var: v, Expr: e}
+}
+
+// DeclAssign creates a short variable declaration.
+func DeclAssign(v string, e Expr) Stmt {
+	return DeclAssignStmt{Var: v, Expr: e}
+}
+
+// Seq creates a sequence of statements.
+func Seq(stmts ...Stmt) Stmt {
+	if len(stmts) == 0 {
+		return NoopStmt{}
+	}
+	if len(stmts) == 1 {
+		return stmts[0]
+	}
+	result := stmts[len(stmts)-1]
+	for i := len(stmts) - 2; i >= 0; i-- {
+		result = SeqStmt{First: stmts[i], Second: result}
+	}
+	return result
+}
+
+// If creates an if statement without init.
+func If(cond Expr, then, els Stmt) Stmt {
+	return IfStmt{Cond: cond, Then: then, Else: els}
+}
+
+// IfInit creates an if statement with init.
+func IfInit(init Stmt, cond Expr, then, els Stmt) Stmt {
+	return IfStmt{Init: init, Cond: cond, Then: then, Else: els}
+}
+
+// Return creates a return statement.
+func Return(e Expr) Stmt {
+	return ReturnStmt{Value: e}
+}
+
+// ReturnVoid creates a bare return statement.
+func ReturnVoid() Stmt {
+	return ReturnStmt{}
+}
+
+// Break creates a break statement.
+func Break() Stmt {
+	return BreakStmt{}
+}
+
+// Continue creates a continue statement.
+func ContinueS() Stmt {
+	return ContinueStmt{}
+}
+
+// Call creates a call statement.
+func Call(fn string, args ...Expr) Stmt {
+	return CallStmt{Call: &CallExpr{Func: fn, Args: args}}
+}
+
+// Block creates a block statement.
+func Block(stmts ...Stmt) Stmt {
+	return BlockStmt{Stmts: stmts}
+}
+
+// Binary creates a binary expression.
+func Binary(op BinaryOp, left, right Expr) Expr {
+	return BinaryExpr{Op: op, Left: left, Right: right}
+}
+
+// Unary creates a unary expression.
+func Unary(op UnaryOp, operand Expr) Expr {
+	return UnaryExpr{Op: op, Operand: operand}
+}
+
+// Not creates a logical not expression.
+func Not(e Expr) Expr {
+	return UnaryExpr{Op: OpNot, Operand: e}
+}
+
+// And creates a logical and expression.
+func And(left, right Expr) Expr {
+	return BinaryExpr{Op: OpAnd, Left: left, Right: right}
+}
+
+// Or creates a logical or expression.
+func Or(left, right Expr) Expr {
+	return BinaryExpr{Op: OpOr, Left: left, Right: right}
+}
+
+// Eq creates an equality expression.
+func Eq(left, right Expr) Expr {
+	return BinaryExpr{Op: OpEq, Left: left, Right: right}
+}
+
+// Neq creates a not-equal expression.
+func Neq(left, right Expr) Expr {
+	return BinaryExpr{Op: OpNeq, Left: left, Right: right}
+}

--- a/internal/minilogic/doc.go
+++ b/internal/minilogic/doc.go
@@ -1,10 +1,17 @@
-// Package minilogic implements a partial formal verification framework
-// for Go AST-based lint rewrites.
+// Package minilogic implements a partial, heuristic verifier for
+// Go AST-based lint rewrites.
 //
-// MiniLogic is designed to verify the semantic equivalence of lint rule
-// transformations, particularly early-return and conditional normalization
-// rewrites. It provides a termination-aware semantic model that can
-// prove or disprove the equivalence of statement blocks.
+// MiniLogic is designed to check semantic equivalence for a restricted
+// statement fragment (not full Go). It is not a formal verification
+// engine: it uses normalization and a limited abstract interpreter,
+// and it can return Unknown for symbolic conditions or unsupported
+// constructs.
+//
+// Limitations (non-exhaustive):
+//   - Not full Go AST; no loops, switch, defer, goto, or closures.
+//   - No memory model, aliasing, pointers, or heap effects.
+//   - Calls are opaque (no side-effect modeling beyond call order).
+//   - Equivalence is inferred via evaluation, not universal proof.
 //
 // Supported lint rule transformations:
 //   - if-else flattening

--- a/internal/minilogic/doc.go
+++ b/internal/minilogic/doc.go
@@ -1,0 +1,21 @@
+// Package minilogic implements a partial formal verification framework
+// for Go AST-based lint rewrites.
+//
+// MiniLogic is designed to verify the semantic equivalence of lint rule
+// transformations, particularly early-return and conditional normalization
+// rewrites. It provides a termination-aware semantic model that can
+// prove or disprove the equivalence of statement blocks.
+//
+// Supported lint rule transformations:
+//   - if-else flattening
+//   - early-return / early-continue / early-break normalization
+//   - boolean condition restructuring in control flow
+//   - merging or splitting conditional returns
+//
+// Out of scope (returns Unknown):
+//   - formatting and stylistic rewrites
+//   - type-conversion simplifications
+//   - reflection or interface-heavy rewrites
+//   - loop transformations
+//   - data-flow or performance-oriented optimizations
+package minilogic

--- a/internal/minilogic/equiv.go
+++ b/internal/minilogic/equiv.go
@@ -1,3 +1,4 @@
+// nolint:goconst
 package minilogic
 
 // VerificationResult represents the result of equivalence verification.

--- a/internal/minilogic/equiv.go
+++ b/internal/minilogic/equiv.go
@@ -1,4 +1,4 @@
-// nolint:goconst
+//nolint:goconst
 package minilogic
 
 // VerificationResult represents the result of equivalence verification.

--- a/internal/minilogic/equiv.go
+++ b/internal/minilogic/equiv.go
@@ -4,8 +4,9 @@ package minilogic
 type VerificationResult int
 
 const (
+	_ VerificationResult = iota
 	// Equivalent indicates the two statements are semantically equivalent.
-	Equivalent VerificationResult = iota
+	Equivalent
 	// NotEquivalent indicates the two statements are not equivalent.
 	NotEquivalent
 	// Unknown indicates equivalence cannot be determined.

--- a/internal/minilogic/equiv.go
+++ b/internal/minilogic/equiv.go
@@ -1,0 +1,465 @@
+package minilogic
+
+// VerificationResult represents the result of equivalence verification.
+type VerificationResult int
+
+const (
+	// Equivalent indicates the two statements are semantically equivalent.
+	Equivalent VerificationResult = iota
+	// NotEquivalent indicates the two statements are not equivalent.
+	NotEquivalent
+	// Unknown indicates equivalence cannot be determined.
+	Unknown
+)
+
+func (r VerificationResult) String() string {
+	switch r {
+	case Equivalent:
+		return "Equivalent"
+	case NotEquivalent:
+		return "NotEquivalent"
+	case Unknown:
+		return "Unknown"
+	default:
+		return "?"
+	}
+}
+
+// ReasonCode provides a reason for the verification result.
+type ReasonCode int
+
+const (
+	ReasonNone ReasonCode = iota
+	ReasonSameResult
+	ReasonDifferentKind
+	ReasonDifferentEnv
+	ReasonDifferentValue
+	ReasonDifferentCalls
+	ReasonSymbolicCondition
+	ReasonOutOfScope
+	ReasonInvalidBreakContinue
+	ReasonCallsDisallowed
+	ReasonScopeViolation
+)
+
+func (r ReasonCode) String() string {
+	switch r {
+	case ReasonNone:
+		return "none"
+	case ReasonSameResult:
+		return "same result for all environments"
+	case ReasonDifferentKind:
+		return "different result kinds"
+	case ReasonDifferentEnv:
+		return "different environments"
+	case ReasonDifferentValue:
+		return "different return values"
+	case ReasonDifferentCalls:
+		return "different call sequences"
+	case ReasonSymbolicCondition:
+		return "symbolic condition - cannot determine branch"
+	case ReasonOutOfScope:
+		return "rewrite outside MiniLogic scope"
+	case ReasonInvalidBreakContinue:
+		return "break/continue outside loop context"
+	case ReasonCallsDisallowed:
+		return "function calls not allowed"
+	case ReasonScopeViolation:
+		return "init-scoped variable used outside scope"
+	default:
+		return "unknown"
+	}
+}
+
+// VerificationReport provides detailed information about verification.
+type VerificationReport struct {
+	Result VerificationResult
+	Reason ReasonCode
+	Detail string
+}
+
+// Verifier verifies the equivalence of statement transformations.
+type Verifier struct {
+	evaluator *Evaluator
+	config    EvalConfig
+}
+
+// NewVerifier creates a new verifier with the given configuration.
+func NewVerifier(config EvalConfig) *Verifier {
+	return &Verifier{
+		evaluator: NewEvaluator(config),
+		config:    config,
+	}
+}
+
+// CheckEquivalence checks if two statements are semantically equivalent.
+// It evaluates both statements with the same input environment and
+// compares the results.
+func (v *Verifier) CheckEquivalence(s1, s2 Stmt) VerificationReport {
+	return v.CheckEquivalenceWithEnv(s1, s2, NewEnv())
+}
+
+// CheckEquivalenceWithEnv checks equivalence given an initial environment.
+func (v *Verifier) CheckEquivalenceWithEnv(s1, s2 Stmt, env *Env) VerificationReport {
+	// Pre-check: validate both statements are within scope
+	if !v.isInScope(s1) || !v.isInScope(s2) {
+		return VerificationReport{
+			Result: Unknown,
+			Reason: ReasonOutOfScope,
+			Detail: "statement contains constructs outside MiniLogic scope",
+		}
+	}
+
+	// Check for scope violations (init-scoped variables used outside)
+	if violation := v.checkScopeViolation(s1); violation != "" {
+		return VerificationReport{
+			Result: Unknown,
+			Reason: ReasonScopeViolation,
+			Detail: violation,
+		}
+	}
+	if violation := v.checkScopeViolation(s2); violation != "" {
+		return VerificationReport{
+			Result: Unknown,
+			Reason: ReasonScopeViolation,
+			Detail: violation,
+		}
+	}
+
+	// Evaluate both statements
+	r1 := v.evaluator.EvalStmt(s1, env)
+	r2 := v.evaluator.EvalStmt(s2, env)
+
+	// Check for Unknown results
+	if r1.Kind == ResultUnknown || r2.Kind == ResultUnknown {
+		return VerificationReport{
+			Result: Unknown,
+			Reason: ReasonSymbolicCondition,
+			Detail: "evaluation produced unknown result",
+		}
+	}
+
+	// Compare result kinds
+	if r1.Kind != r2.Kind {
+		return VerificationReport{
+			Result: NotEquivalent,
+			Reason: ReasonDifferentKind,
+			Detail: "result kinds differ: " + r1.Kind.String() + " vs " + r2.Kind.String(),
+		}
+	}
+
+	// Compare based on kind
+	switch r1.Kind {
+	case ResultContinue:
+		if !r1.Env.Equal(r2.Env) {
+			return VerificationReport{
+				Result: NotEquivalent,
+				Reason: ReasonDifferentEnv,
+				Detail: "environments differ: " + r1.Env.String() + " vs " + r2.Env.String(),
+			}
+		}
+
+	case ResultReturn:
+		if r1.Value == nil && r2.Value == nil {
+			// Both nil, ok
+		} else if r1.Value == nil || r2.Value == nil {
+			return VerificationReport{
+				Result: NotEquivalent,
+				Reason: ReasonDifferentValue,
+				Detail: "return values differ (nil vs non-nil)",
+			}
+		} else if !r1.Value.Equal(r2.Value) {
+			return VerificationReport{
+				Result: NotEquivalent,
+				Reason: ReasonDifferentValue,
+				Detail: "return values differ: " + r1.Value.String() + " vs " + r2.Value.String(),
+			}
+		}
+
+	case ResultBreak, ResultContinueLoop:
+		// Kind match is sufficient
+	}
+
+	// Compare call sequences (for OpaqueCalls policy)
+	if v.config.CallPolicy == OpaqueCalls {
+		if !callSequencesEqual(r1.Calls, r2.Calls) {
+			return VerificationReport{
+				Result: NotEquivalent,
+				Reason: ReasonDifferentCalls,
+				Detail: "call sequences differ",
+			}
+		}
+	}
+
+	return VerificationReport{
+		Result: Equivalent,
+		Reason: ReasonSameResult,
+		Detail: "statements produce identical results",
+	}
+}
+
+func callSequencesEqual(a, b []CallRecord) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !callsEqual(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// isInScope checks if a statement is within MiniLogic's modeling scope.
+func (v *Verifier) isInScope(stmt Stmt) bool {
+	switch s := stmt.(type) {
+	case AssignStmt, DeclAssignStmt, NoopStmt:
+		return true
+
+	case SeqStmt:
+		return v.isInScope(s.First) && v.isInScope(s.Second)
+
+	case BlockStmt:
+		for _, st := range s.Stmts {
+			if !v.isInScope(st) {
+				return false
+			}
+		}
+		return true
+
+	case IfStmt:
+		if s.Init != nil && !v.isInScope(s.Init) {
+			return false
+		}
+		if !v.isInScope(s.Then) {
+			return false
+		}
+		if s.Else != nil && !v.isInScope(s.Else) {
+			return false
+		}
+		return true
+
+	case ReturnStmt:
+		return v.config.ControlFlowMode == EarlyReturnAware
+
+	case BreakStmt, ContinueStmt:
+		return v.config.ControlFlowMode == EarlyReturnAware && v.config.InLoopContext
+
+	case CallStmt:
+		return v.config.CallPolicy == OpaqueCalls
+
+	default:
+		return false
+	}
+}
+
+// checkScopeViolation checks for init-scoped variables used outside their scope.
+func (v *Verifier) checkScopeViolation(stmt Stmt) string {
+	// Collect init-scoped variables
+	initVars := make(map[string]bool)
+	v.collectInitVars(stmt, initVars)
+
+	// Check for violations
+	return v.checkViolation(stmt, initVars, false, make(map[string]bool))
+}
+
+func (v *Verifier) collectInitVars(stmt Stmt, vars map[string]bool) {
+	switch s := stmt.(type) {
+	case SeqStmt:
+		v.collectInitVars(s.First, vars)
+		v.collectInitVars(s.Second, vars)
+
+	case BlockStmt:
+		for _, st := range s.Stmts {
+			v.collectInitVars(st, vars)
+		}
+
+	case IfStmt:
+		if s.Init != nil {
+			if decl, ok := s.Init.(DeclAssignStmt); ok {
+				vars[decl.Var] = true
+			}
+		}
+		v.collectInitVars(s.Then, vars)
+		if s.Else != nil {
+			v.collectInitVars(s.Else, vars)
+		}
+	}
+}
+
+func (v *Verifier) checkViolation(stmt Stmt, initVars map[string]bool, inIfScope bool, currentScopeVars map[string]bool) string {
+	switch s := stmt.(type) {
+	case AssignStmt:
+		// Using init var outside if scope is a violation
+		// But if it's in currentScopeVars, it's allowed in this scope
+		if !inIfScope && initVars[s.Var] && !currentScopeVars[s.Var] {
+			return "init-scoped variable '" + s.Var + "' assigned outside if scope"
+		}
+		// Check expression for variable references
+		if ref := v.checkExprViolation(s.Expr, initVars, inIfScope, currentScopeVars); ref != "" {
+			return ref
+		}
+
+	case SeqStmt:
+		if ref := v.checkViolation(s.First, initVars, inIfScope, currentScopeVars); ref != "" {
+			return ref
+		}
+		if ref := v.checkViolation(s.Second, initVars, inIfScope, currentScopeVars); ref != "" {
+			return ref
+		}
+
+	case BlockStmt:
+		for _, st := range s.Stmts {
+			if ref := v.checkViolation(st, initVars, inIfScope, currentScopeVars); ref != "" {
+				return ref
+			}
+		}
+
+	case IfStmt:
+		// Variables declared in init are scoped to this if statement
+		localInitVars := make(map[string]bool)
+		for k, val := range initVars {
+			localInitVars[k] = val
+		}
+
+		// Track variables declared in this if's init
+		localScopeVars := make(map[string]bool)
+		if s.Init != nil {
+			if decl, ok := s.Init.(DeclAssignStmt); ok {
+				localInitVars[decl.Var] = true
+				localScopeVars[decl.Var] = true
+			}
+		}
+
+		// Check condition - init vars are valid here
+		if ref := v.checkExprViolation(s.Cond, initVars, true, localScopeVars); ref != "" {
+			return ref
+		}
+
+		// Then and Else are within the if scope, init vars are valid
+		if ref := v.checkViolation(s.Then, localInitVars, true, localScopeVars); ref != "" {
+			return ref
+		}
+		if s.Else != nil {
+			if ref := v.checkViolation(s.Else, localInitVars, true, localScopeVars); ref != "" {
+				return ref
+			}
+		}
+
+	case ReturnStmt:
+		if s.Value != nil {
+			if ref := v.checkExprViolation(s.Value, initVars, inIfScope, currentScopeVars); ref != "" {
+				return ref
+			}
+		}
+
+	case CallStmt:
+		for _, arg := range s.Call.Args {
+			if ref := v.checkExprViolation(arg, initVars, inIfScope, currentScopeVars); ref != "" {
+				return ref
+			}
+		}
+	}
+
+	return ""
+}
+
+func (v *Verifier) checkExprViolation(expr Expr, initVars map[string]bool, inIfScope bool, currentScopeVars map[string]bool) string {
+	switch e := expr.(type) {
+	case VarExpr:
+		// A variable is valid if:
+		// 1. We're in if scope and it's in currentScopeVars (declared in this if's init)
+		// 2. We're in if scope generally
+		// 3. It's not an init-scoped variable
+		if initVars[e.Name] && !inIfScope && !currentScopeVars[e.Name] {
+			return "init-scoped variable '" + e.Name + "' referenced outside if scope"
+		}
+
+	case BinaryExpr:
+		if ref := v.checkExprViolation(e.Left, initVars, inIfScope, currentScopeVars); ref != "" {
+			return ref
+		}
+		if ref := v.checkExprViolation(e.Right, initVars, inIfScope, currentScopeVars); ref != "" {
+			return ref
+		}
+
+	case UnaryExpr:
+		if ref := v.checkExprViolation(e.Operand, initVars, inIfScope, currentScopeVars); ref != "" {
+			return ref
+		}
+
+	case CallExpr:
+		for _, arg := range e.Args {
+			if ref := v.checkExprViolation(arg, initVars, inIfScope, currentScopeVars); ref != "" {
+				return ref
+			}
+		}
+	}
+
+	return ""
+}
+
+// VerifyEarlyReturnRewrite verifies that an early-return rewrite is valid.
+// Original:
+//
+//	if cond { return v } else { S }
+//
+// Rewritten:
+//
+//	if cond { return v }; S
+func (v *Verifier) VerifyEarlyReturnRewrite(cond Expr, returnVal Expr, elseStmt Stmt) VerificationReport {
+	// Original form
+	original := If(cond, Return(returnVal), elseStmt)
+
+	// Rewritten form
+	rewritten := Seq(If(cond, Return(returnVal), nil), elseStmt)
+
+	return v.CheckEquivalence(original, rewritten)
+}
+
+// VerifyIfElseChainFlattening verifies that if-else chain flattening is valid.
+// Original:
+//
+//	if c1 { return v1 }
+//	else if c2 { return v2 }
+//	else { return v3 }
+//
+// Rewritten:
+//
+//	if c1 { return v1 }
+//	if c2 { return v2 }
+//	return v3
+func (v *Verifier) VerifyIfElseChainFlattening(conditions []Expr, returns []Expr, fallback Expr) VerificationReport {
+	if len(conditions) != len(returns) {
+		return VerificationReport{
+			Result: Unknown,
+			Reason: ReasonOutOfScope,
+			Detail: "mismatched conditions and returns",
+		}
+	}
+
+	if len(conditions) == 0 {
+		return VerificationReport{
+			Result: Equivalent,
+			Reason: ReasonSameResult,
+			Detail: "empty chain",
+		}
+	}
+
+	// Build original (nested if-else chain)
+	var original Stmt
+	original = Return(fallback)
+	for i := len(conditions) - 1; i >= 0; i-- {
+		original = If(conditions[i], Return(returns[i]), original)
+	}
+
+	// Build rewritten (flat if sequence)
+	stmts := make([]Stmt, 0, len(conditions)+1)
+	for i := 0; i < len(conditions); i++ {
+		stmts = append(stmts, If(conditions[i], Return(returns[i]), nil))
+	}
+	stmts = append(stmts, Return(fallback))
+	rewritten := Seq(stmts...)
+
+	return v.CheckEquivalence(original, rewritten)
+}

--- a/internal/minilogic/eval.go
+++ b/internal/minilogic/eval.go
@@ -4,9 +4,10 @@ package minilogic
 type CallPolicy int
 
 const (
+	_ CallPolicy = iota
 	// OpaqueCalls treats calls as opaque effects.
 	// Calls always evaluate to Continue, but call order/multiplicity is tracked.
-	OpaqueCalls CallPolicy = iota
+	OpaqueCalls
 	// DisallowCalls rejects any block containing calls as Unknown.
 	DisallowCalls
 )
@@ -15,8 +16,9 @@ const (
 type ControlFlowMode int
 
 const (
+	_ ControlFlowMode = iota
 	// NoTermination does not model termination statements.
-	NoTermination ControlFlowMode = iota
+	NoTermination
 	// EarlyReturnAware models return, break, continue statements.
 	EarlyReturnAware
 )

--- a/internal/minilogic/eval.go
+++ b/internal/minilogic/eval.go
@@ -403,16 +403,16 @@ func (ev *Evaluator) evalIfStmt(s IfStmt, env *Env, calls []CallRecord) Result {
 	var initVarNames []string
 
 	// Handle init statement
-		if s.Init != nil {
-			// Track variables declared in init (for scope cleanup later)
-			switch decl := s.Init.(type) {
-			case DeclAssignStmt:
-				initVarNames = append(initVarNames, decl.Var)
-			case DeclAssignMultiStmt:
-				initVarNames = append(initVarNames, decl.Vars...)
-			case VarDeclStmt:
-				initVarNames = append(initVarNames, decl.Var)
-			}
+	if s.Init != nil {
+		// Track variables declared in init (for scope cleanup later)
+		switch decl := s.Init.(type) {
+		case DeclAssignStmt:
+			initVarNames = append(initVarNames, decl.Var)
+		case DeclAssignMultiStmt:
+			initVarNames = append(initVarNames, decl.Vars...)
+		case VarDeclStmt:
+			initVarNames = append(initVarNames, decl.Var)
+		}
 
 		// Create a child scope for init-bound variables
 		childEnv := NewChildEnv(env)

--- a/internal/minilogic/eval.go
+++ b/internal/minilogic/eval.go
@@ -1,0 +1,471 @@
+package minilogic
+
+// CallPolicy determines how function calls are handled.
+type CallPolicy int
+
+const (
+	// OpaqueCalls treats calls as opaque effects.
+	// Calls always evaluate to Continue, but call order/multiplicity is tracked.
+	OpaqueCalls CallPolicy = iota
+	// DisallowCalls rejects any block containing calls as Unknown.
+	DisallowCalls
+)
+
+// ControlFlowMode determines how control flow is handled.
+type ControlFlowMode int
+
+const (
+	// NoTermination does not model termination statements.
+	NoTermination ControlFlowMode = iota
+	// EarlyReturnAware models return, break, continue statements.
+	EarlyReturnAware
+)
+
+// EvalConfig holds configuration for the evaluator.
+type EvalConfig struct {
+	CallPolicy      CallPolicy
+	ControlFlowMode ControlFlowMode
+	InLoopContext   bool // true if we're inside a loop
+}
+
+// DefaultConfig returns the default evaluation configuration.
+func DefaultConfig() EvalConfig {
+	return EvalConfig{
+		CallPolicy:      OpaqueCalls,
+		ControlFlowMode: EarlyReturnAware,
+		InLoopContext:   false,
+	}
+}
+
+// Evaluator evaluates expressions and statements.
+type Evaluator struct {
+	config EvalConfig
+}
+
+// NewEvaluator creates a new evaluator with the given configuration.
+func NewEvaluator(config EvalConfig) *Evaluator {
+	return &Evaluator{config: config}
+}
+
+// EvalExpr evaluates an expression in the given environment.
+// Returns the resulting value.
+func (ev *Evaluator) EvalExpr(expr Expr, env *Env) Value {
+	switch e := expr.(type) {
+	case LiteralExpr:
+		return e.Val
+
+	case VarExpr:
+		val := env.Get(e.Name)
+		if val == nil {
+			// Variable not found, return symbolic value
+			return SymbolicValue{Name: e.Name}
+		}
+		return val
+
+	case BinaryExpr:
+		left := ev.EvalExpr(e.Left, env)
+		right := ev.EvalExpr(e.Right, env)
+		return ev.evalBinary(e.Op, left, right)
+
+	case UnaryExpr:
+		operand := ev.EvalExpr(e.Operand, env)
+		return ev.evalUnary(e.Op, operand)
+
+	case CallExpr:
+		// Evaluate arguments but return symbolic value
+		// (calls are side-effecting and return unknown values)
+		return SymbolicValue{Name: "call_" + e.Func}
+
+	default:
+		return SymbolicValue{Name: "unknown"}
+	}
+}
+
+func exprHasCall(expr Expr) bool {
+	switch e := expr.(type) {
+	case CallExpr:
+		return true
+	case BinaryExpr:
+		return exprHasCall(e.Left) || exprHasCall(e.Right)
+	case UnaryExpr:
+		return exprHasCall(e.Operand)
+	default:
+		return false
+	}
+}
+
+func (ev *Evaluator) evalBinary(op BinaryOp, left, right Value) Value {
+	// Handle symbolic values
+	_, leftSym := left.(SymbolicValue)
+	_, rightSym := right.(SymbolicValue)
+	if leftSym || rightSym {
+		return SymbolicValue{Name: "binary_result"}
+	}
+
+	switch op {
+	case OpAdd:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				return IntValue{Val: l.Val + r.Val}
+			}
+		}
+		if l, ok := left.(StringValue); ok {
+			if r, ok := right.(StringValue); ok {
+				return StringValue{Val: l.Val + r.Val}
+			}
+		}
+
+	case OpSub:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				return IntValue{Val: l.Val - r.Val}
+			}
+		}
+
+	case OpMul:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				return IntValue{Val: l.Val * r.Val}
+			}
+		}
+
+	case OpDiv:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				if r.Val != 0 {
+					return IntValue{Val: l.Val / r.Val}
+				}
+			}
+		}
+
+	case OpMod:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				if r.Val != 0 {
+					return IntValue{Val: l.Val % r.Val}
+				}
+			}
+		}
+
+	case OpEq:
+		return BoolValue{Val: left.Equal(right)}
+
+	case OpNeq:
+		return BoolValue{Val: !left.Equal(right)}
+
+	case OpLt:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				return BoolValue{Val: l.Val < r.Val}
+			}
+		}
+
+	case OpLte:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				return BoolValue{Val: l.Val <= r.Val}
+			}
+		}
+
+	case OpGt:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				return BoolValue{Val: l.Val > r.Val}
+			}
+		}
+
+	case OpGte:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				return BoolValue{Val: l.Val >= r.Val}
+			}
+		}
+
+	case OpAnd:
+		if l, ok := left.(BoolValue); ok {
+			if r, ok := right.(BoolValue); ok {
+				return BoolValue{Val: l.Val && r.Val}
+			}
+		}
+
+	case OpOr:
+		if l, ok := left.(BoolValue); ok {
+			if r, ok := right.(BoolValue); ok {
+				return BoolValue{Val: l.Val || r.Val}
+			}
+		}
+	}
+
+	return SymbolicValue{Name: "binary_result"}
+}
+
+func (ev *Evaluator) evalUnary(op UnaryOp, operand Value) Value {
+	if _, ok := operand.(SymbolicValue); ok {
+		return SymbolicValue{Name: "unary_result"}
+	}
+
+	switch op {
+	case OpNot:
+		if b, ok := operand.(BoolValue); ok {
+			return BoolValue{Val: !b.Val}
+		}
+
+	case OpNeg:
+		if i, ok := operand.(IntValue); ok {
+			return IntValue{Val: -i.Val}
+		}
+	}
+
+	return SymbolicValue{Name: "unary_result"}
+}
+
+// IsTruthy returns true if the value is truthy.
+func IsTruthy(v Value) bool {
+	switch val := v.(type) {
+	case BoolValue:
+		return val.Val
+	case IntValue:
+		return val.Val != 0
+	case StringValue:
+		return val.Val != ""
+	case NilValue:
+		return false
+	case SymbolicValue:
+		// Symbolic values are treated as potentially truthy
+		return true
+	default:
+		return true
+	}
+}
+
+// IsKnownTrue returns true if the value is definitively true.
+func IsKnownTrue(v Value) bool {
+	if b, ok := v.(BoolValue); ok {
+		return b.Val
+	}
+	return false
+}
+
+// IsKnownFalse returns true if the value is definitively false.
+func IsKnownFalse(v Value) bool {
+	if b, ok := v.(BoolValue); ok {
+		return !b.Val
+	}
+	return false
+}
+
+// EvalStmt evaluates a statement in the given environment.
+// Returns the result of execution.
+func (ev *Evaluator) EvalStmt(stmt Stmt, env *Env) Result {
+	return ev.evalStmt(stmt, env, nil)
+}
+
+func (ev *Evaluator) evalStmt(stmt Stmt, env *Env, calls []CallRecord) Result {
+	switch s := stmt.(type) {
+	case AssignStmt:
+		if ev.config.CallPolicy == DisallowCalls && exprHasCall(s.Expr) {
+			return UnknownResult()
+		}
+		val := ev.EvalExpr(s.Expr, env)
+		newEnv := env.Clone()
+		newEnv.Set(s.Var, val)
+		return ContinueResultWithCalls(newEnv, calls)
+
+	case DeclAssignStmt:
+		if ev.config.CallPolicy == DisallowCalls && exprHasCall(s.Expr) {
+			return UnknownResult()
+		}
+		val := ev.EvalExpr(s.Expr, env)
+		newEnv := env.Clone()
+		newEnv.Set(s.Var, val)
+		return ContinueResultWithCalls(newEnv, calls)
+
+	case SeqStmt:
+		// Evaluate first statement
+		r1 := ev.evalStmt(s.First, env, calls)
+		// If not Continue, short-circuit and return the result
+		if r1.Kind != ResultContinue {
+			return r1
+		}
+		// Continue with second statement
+		return ev.evalStmt(s.Second, r1.Env, r1.Calls)
+
+	case BlockStmt:
+		if len(s.Stmts) == 0 {
+			return ContinueResultWithCalls(env, calls)
+		}
+		currentEnv := env
+		currentCalls := calls
+		for _, stmt := range s.Stmts {
+			r := ev.evalStmt(stmt, currentEnv, currentCalls)
+			if r.Kind != ResultContinue {
+				return r
+			}
+			currentEnv = r.Env
+			currentCalls = r.Calls
+		}
+		return ContinueResultWithCalls(currentEnv, currentCalls)
+
+	case IfStmt:
+		return ev.evalIfStmt(s, env, calls)
+
+	case ReturnStmt:
+		if ev.config.ControlFlowMode == NoTermination {
+			return UnknownResult()
+		}
+		var val Value
+		if s.Value != nil {
+			if ev.config.CallPolicy == DisallowCalls && exprHasCall(s.Value) {
+				return UnknownResult()
+			}
+			val = ev.EvalExpr(s.Value, env)
+		} else {
+			val = NilValue{}
+		}
+		return ReturnResult(val, calls)
+
+	case BreakStmt:
+		if ev.config.ControlFlowMode == NoTermination {
+			return UnknownResult()
+		}
+		if !ev.config.InLoopContext {
+			// break outside loop is invalid
+			return UnknownResult()
+		}
+		return BreakResult(calls)
+
+	case ContinueStmt:
+		if ev.config.ControlFlowMode == NoTermination {
+			return UnknownResult()
+		}
+		if !ev.config.InLoopContext {
+			// continue outside loop is invalid
+			return UnknownResult()
+		}
+		return ContinueLoopResult(calls)
+
+	case CallStmt:
+		return ev.evalCallStmt(s, env, calls)
+
+	case NoopStmt:
+		return ContinueResultWithCalls(env, calls)
+
+	default:
+		return UnknownResult()
+	}
+}
+
+func (ev *Evaluator) evalIfStmt(s IfStmt, env *Env, calls []CallRecord) Result {
+	workingEnv := env
+	workingCalls := calls
+	var initVarNames []string
+
+	// Handle init statement
+	if s.Init != nil {
+		// Track variables declared in init (for scope cleanup later)
+		if decl, ok := s.Init.(DeclAssignStmt); ok {
+			initVarNames = append(initVarNames, decl.Var)
+		}
+
+		// Create a child scope for init-bound variables
+		childEnv := NewChildEnv(env)
+		initResult := ev.evalStmt(s.Init, childEnv, workingCalls)
+		if initResult.Kind != ResultContinue {
+			return initResult
+		}
+		workingEnv = initResult.Env
+		workingCalls = initResult.Calls
+	}
+
+	// Evaluate condition
+	if ev.config.CallPolicy == DisallowCalls && exprHasCall(s.Cond) {
+		return UnknownResult()
+	}
+	condVal := ev.EvalExpr(s.Cond, workingEnv)
+
+	// If condition is symbolic, we cannot determine which branch to take
+	if _, ok := condVal.(SymbolicValue); ok {
+		// For symbolic conditions, we need to analyze both branches
+		// and return Unknown if they differ
+		result := ev.evalSymbolicIf(s, workingEnv, workingCalls)
+		return ev.cleanupInitVars(result, env, initVarNames)
+	}
+
+	// Execute appropriate branch
+	var branchResult Result
+	if IsTruthy(condVal) {
+		branchResult = ev.evalStmt(s.Then, workingEnv, workingCalls)
+	} else if s.Else != nil {
+		branchResult = ev.evalStmt(s.Else, workingEnv, workingCalls)
+	} else {
+		// No else branch, condition is false: fall through with init effects
+		// while removing init-scoped variables.
+		return ev.cleanupInitVars(ContinueResultWithCalls(workingEnv, workingCalls), env, initVarNames)
+	}
+
+	// Clean up init-scoped variables from Continue results
+	return ev.cleanupInitVars(branchResult, env, initVarNames)
+}
+
+// cleanupInitVars removes init-scoped variables from Continue results.
+// This ensures Go's scoping rules are respected: variables declared in
+// if-init are not visible after the if statement.
+func (ev *Evaluator) cleanupInitVars(result Result, originalEnv *Env, initVarNames []string) Result {
+	// Only clean up Continue results; terminating results don't expose the environment
+	if result.Kind != ResultContinue || len(initVarNames) == 0 {
+		return result
+	}
+
+	// Build a set for fast lookup
+	initVars := make(map[string]bool)
+	for _, name := range initVarNames {
+		initVars[name] = true
+	}
+
+	// Create a new environment based on the original, then copy non-init changes
+	newEnv := originalEnv.Clone()
+
+	// Copy all variables from result.Env that are not init vars
+	for _, key := range result.Env.Keys() {
+		if !initVars[key] {
+			newEnv.Set(key, result.Env.Get(key))
+		}
+	}
+
+	return ContinueResultWithCalls(newEnv, result.Calls)
+}
+
+func (ev *Evaluator) evalSymbolicIf(s IfStmt, env *Env, calls []CallRecord) Result {
+	// For symbolic conditions, evaluate both branches
+	thenResult := ev.evalStmt(s.Then, env, calls)
+
+	var elseResult Result
+	if s.Else != nil {
+		elseResult = ev.evalStmt(s.Else, env, calls)
+	} else {
+		elseResult = ContinueResultWithCalls(env, calls)
+	}
+
+	// If both branches have the same result kind and value, we can return that
+	if thenResult.Equal(elseResult) {
+		return thenResult
+	}
+
+	// Otherwise, return Unknown (we cannot determine the result)
+	return UnknownResult()
+}
+
+func (ev *Evaluator) evalCallStmt(s CallStmt, env *Env, calls []CallRecord) Result {
+	if ev.config.CallPolicy == DisallowCalls {
+		return UnknownResult()
+	}
+
+	// OpaqueCalls: track the call but continue execution
+	args := make([]Value, len(s.Call.Args))
+	for i, arg := range s.Call.Args {
+		args[i] = ev.EvalExpr(arg, env)
+	}
+
+	newCalls := append(calls, CallRecord{Func: s.Call.Func, Args: args})
+	return ContinueResultWithCalls(env, newCalls)
+}

--- a/internal/minilogic/eval.go
+++ b/internal/minilogic/eval.go
@@ -44,6 +44,7 @@ func DefaultConfig() EvalConfig {
 }
 
 // Evaluator evaluates expressions and statements.
+// It is a lightweight abstract interpreter, not a full Go semantics model.
 type Evaluator struct {
 	config EvalConfig
 }

--- a/internal/minilogic/eval.go
+++ b/internal/minilogic/eval.go
@@ -29,6 +29,7 @@ type EvalConfig struct {
 	ControlFlowMode ControlFlowMode
 	InLoopContext   bool // true if we're inside a loop
 	CondSolver      CondSolver
+	DebugIR         bool
 }
 
 // DefaultConfig returns the default evaluation configuration.
@@ -38,6 +39,7 @@ func DefaultConfig() EvalConfig {
 		ControlFlowMode: EarlyReturnAware,
 		InLoopContext:   false,
 		CondSolver:      BasicCondSolver{},
+		DebugIR:         false,
 	}
 }
 

--- a/internal/minilogic/ir.go
+++ b/internal/minilogic/ir.go
@@ -1,0 +1,178 @@
+package minilogic
+
+import (
+	"sort"
+	"strings"
+)
+
+// IRReport captures the IR for original and transformed statements.
+type IRReport struct {
+	Original    string
+	Transformed string
+}
+
+func (v *Verifier) withDebugIR(report VerificationReport, original, transformed Stmt, env *Env) VerificationReport {
+	if !v.config.DebugIR {
+		return report
+	}
+
+	ir := buildIRReport(original, transformed, env, v.config)
+	report.IR = &ir
+
+	report.Detail = strings.TrimSpace(report.Detail)
+	if report.Detail != "" {
+		report.Detail += "\n"
+	}
+	report.Detail += "IR(original):\n" + indentIR(ir.Original) + "\nIR(transformed):\n" + indentIR(ir.Transformed)
+
+	return report
+}
+
+func buildIRReport(original, transformed Stmt, env *Env, config EvalConfig) IRReport {
+	irOriginal := formatStmtIR(original, env, config)
+	irTransformed := formatStmtIR(transformed, env, config)
+	return IRReport{
+		Original:    irOriginal,
+		Transformed: irTransformed,
+	}
+}
+
+func formatStmtIR(stmt Stmt, env *Env, config EvalConfig) string {
+	ev := NewEvaluator(config)
+	base := cloneEnvForEval(env)
+	result := ev.EvalStmt(stmt, base)
+	return formatResultIRPretty(result)
+}
+
+func cloneEnvForEval(env *Env) *Env {
+	if env == nil {
+		return NewEnv()
+	}
+	return env.Clone()
+}
+
+func formatResultIR(result Result) string {
+	switch result.Kind {
+	case ResultContinue:
+		return "Continue(env=" + formatEnvIR(result.Env) + ", calls=" + formatCallsIR(result.Calls) + ")"
+	case ResultReturn:
+		if result.Value == nil {
+			return "Return(value=nil, calls=" + formatCallsIR(result.Calls) + ")"
+		}
+		return "Return(value=" + result.Value.String() + ", calls=" + formatCallsIR(result.Calls) + ")"
+	case ResultBreak:
+		return "Break(calls=" + formatCallsIR(result.Calls) + ")"
+	case ResultContinueLoop:
+		return "ContinueLoop(calls=" + formatCallsIR(result.Calls) + ")"
+	case ResultUnknown:
+		return "Unknown"
+	default:
+		return "Unknown"
+	}
+}
+
+func formatResultIRPretty(result Result) string {
+	switch result.Kind {
+	case ResultContinue:
+		return "Continue(\n  env = " + formatEnvIRPretty(result.Env) + "\n  calls = " + formatCallsIRPretty(result.Calls) + "\n)"
+	case ResultReturn:
+		if result.Value == nil {
+			return "Return(\n  value = nil\n  calls = " + formatCallsIRPretty(result.Calls) + "\n)"
+		}
+		return "Return(\n  value = " + result.Value.String() + "\n  calls = " + formatCallsIRPretty(result.Calls) + "\n)"
+	case ResultBreak:
+		return "Break(\n  calls = " + formatCallsIRPretty(result.Calls) + "\n)"
+	case ResultContinueLoop:
+		return "ContinueLoop(\n  calls = " + formatCallsIRPretty(result.Calls) + "\n)"
+	case ResultUnknown:
+		return "Unknown"
+	default:
+		return "Unknown"
+	}
+}
+
+func formatEnvIR(env *Env) string {
+	if env == nil {
+		return "{}"
+	}
+	keys := make(map[string]struct{})
+	env.collectKeys(keys)
+	if len(keys) == 0 {
+		return "{}"
+	}
+	sorted := make([]string, 0, len(keys))
+	for k := range keys {
+		sorted = append(sorted, k)
+	}
+	sort.Strings(sorted)
+
+	parts := make([]string, 0, len(sorted))
+	for _, key := range sorted {
+		val := env.Get(key)
+		if val == nil {
+			parts = append(parts, key+"=nil")
+			continue
+		}
+		parts = append(parts, key+"="+val.String())
+	}
+
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+func formatEnvIRPretty(env *Env) string {
+	if env == nil {
+		return "{}"
+	}
+	keys := make(map[string]struct{})
+	env.collectKeys(keys)
+	if len(keys) == 0 {
+		return "{}"
+	}
+	sorted := make([]string, 0, len(keys))
+	for k := range keys {
+		sorted = append(sorted, k)
+	}
+	sort.Strings(sorted)
+
+	lines := make([]string, 0, len(sorted))
+	for _, key := range sorted {
+		val := env.Get(key)
+		if val == nil {
+			lines = append(lines, "  "+key+" = nil")
+			continue
+		}
+		lines = append(lines, "  "+key+" = "+val.String())
+	}
+
+	return "{\n" + strings.Join(lines, "\n") + "\n}"
+}
+
+func formatCallsIR(calls []CallRecord) string {
+	if len(calls) == 0 {
+		return "[]"
+	}
+	parts := make([]string, 0, len(calls))
+	for _, call := range calls {
+		parts = append(parts, call.String())
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+func formatCallsIRPretty(calls []CallRecord) string {
+	if len(calls) == 0 {
+		return "[]"
+	}
+	parts := make([]string, 0, len(calls))
+	for _, call := range calls {
+		parts = append(parts, call.String())
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+func indentIR(value string) string {
+	lines := strings.Split(value, "\n")
+	for i := range lines {
+		lines[i] = "  " + lines[i]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/minilogic/ir.go
+++ b/internal/minilogic/ir.go
@@ -29,11 +29,9 @@ func (v *Verifier) withDebugIR(report VerificationReport, original, transformed 
 }
 
 func buildIRReport(original, transformed Stmt, env *Env, config EvalConfig) IRReport {
-	irOriginal := formatStmtIR(original, env, config)
-	irTransformed := formatStmtIR(transformed, env, config)
 	return IRReport{
-		Original:    irOriginal,
-		Transformed: irTransformed,
+		Original:    formatStmtIR(original, env, config),
+		Transformed: formatStmtIR(transformed, env, config),
 	}
 }
 

--- a/internal/minilogic/ir.go
+++ b/internal/minilogic/ir.go
@@ -49,7 +49,7 @@ func cloneEnvForEval(env *Env) *Env {
 	return env.Clone()
 }
 
-// nolint:unused
+//nolint:unused
 func formatResultIR(result Result) string {
 	switch result.Kind {
 	case ResultContinue:

--- a/internal/minilogic/ir.go
+++ b/internal/minilogic/ir.go
@@ -49,6 +49,7 @@ func cloneEnvForEval(env *Env) *Env {
 	return env.Clone()
 }
 
+// nolint:unused
 func formatResultIR(result Result) string {
 	switch result.Kind {
 	case ResultContinue:
@@ -89,6 +90,7 @@ func formatResultIRPretty(result Result) string {
 	}
 }
 
+//nolint:unused
 func formatEnvIR(env *Env) string {
 	if env == nil {
 		return "{}"
@@ -145,6 +147,7 @@ func formatEnvIRPretty(env *Env) string {
 	return "{\n" + strings.Join(lines, "\n") + "\n}"
 }
 
+//nolint:unused
 func formatCallsIR(calls []CallRecord) string {
 	if len(calls) == 0 {
 		return "[]"

--- a/internal/minilogic/minilogic_test.go
+++ b/internal/minilogic/minilogic_test.go
@@ -1,0 +1,902 @@
+package minilogic
+
+import (
+	"testing"
+)
+
+// =======================
+// Core Evaluation Engine Tests
+// =======================
+
+func TestAssignmentEquivalence(t *testing.T) {
+	ml := New()
+
+	// x = 1 vs x = 1 should be equivalent
+	s1 := Assign("x", IntLit(1))
+	s2 := Assign("x", IntLit(1))
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestSequenceEquivalence(t *testing.T) {
+	ml := New()
+
+	// x = 1; y = 2 vs x = 1; y = 2 should be equivalent
+	s1 := Seq(Assign("x", IntLit(1)), Assign("y", IntLit(2)))
+	s2 := Seq(Assign("x", IntLit(1)), Assign("y", IntLit(2)))
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestAssignmentNotEquivalent(t *testing.T) {
+	ml := New()
+
+	// x = 1 vs x = 2 should not be equivalent
+	s1 := Assign("x", IntLit(1))
+	s2 := Assign("x", IntLit(2))
+
+	report := ml.Verify(s1, s2)
+	if report.Result != NotEquivalent {
+		t.Errorf("Expected NotEquivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestIfElseConstantTrue(t *testing.T) {
+	ml := New()
+
+	// if true { x = 1 } else { x = 2 } is equivalent to x = 1
+	s1 := If(BoolLit(true), Assign("x", IntLit(1)), Assign("x", IntLit(2)))
+	s2 := Assign("x", IntLit(1))
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestIfElseConstantFalse(t *testing.T) {
+	ml := New()
+
+	// if false { x = 1 } else { x = 2 } is equivalent to x = 2
+	s1 := If(BoolLit(false), Assign("x", IntLit(1)), Assign("x", IntLit(2)))
+	s2 := Assign("x", IntLit(2))
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestExpressionEvaluation(t *testing.T) {
+	ml := New()
+	env := NewEnv()
+	env.Set("x", IntValue{Val: 10})
+
+	// Test arithmetic
+	val := ml.EvaluateExpr(Binary(OpAdd, Var("x"), IntLit(5)), env)
+	if iv, ok := val.(IntValue); !ok || iv.Val != 15 {
+		t.Errorf("Expected 15, got %v", val)
+	}
+
+	// Test comparison
+	val = ml.EvaluateExpr(Binary(OpGt, Var("x"), IntLit(5)), env)
+	if bv, ok := val.(BoolValue); !ok || !bv.Val {
+		t.Errorf("Expected true, got %v", val)
+	}
+}
+
+// =======================
+// Termination-Aware Tests
+// =======================
+
+func TestReturnEquivalence(t *testing.T) {
+	ml := New()
+
+	// return 1 vs return 1 should be equivalent
+	s1 := Return(IntLit(1))
+	s2 := Return(IntLit(1))
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestReturnNotEquivalent(t *testing.T) {
+	ml := New()
+
+	// return 1 vs return 2 should not be equivalent
+	s1 := Return(IntLit(1))
+	s2 := Return(IntLit(2))
+
+	report := ml.Verify(s1, s2)
+	if report.Result != NotEquivalent {
+		t.Errorf("Expected NotEquivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestIfReturnEquivalence(t *testing.T) {
+	ml := New()
+
+	// if cond { return 1 } else { return 2 } vs same should be equivalent
+	cond := BoolLit(true)
+	s1 := If(cond, Return(IntLit(1)), Return(IntLit(2)))
+	s2 := If(cond, Return(IntLit(1)), Return(IntLit(2)))
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestSequencingShortCircuit(t *testing.T) {
+	ml := New()
+
+	// return 1; x = 2 is equivalent to return 1 (short-circuit)
+	s1 := Seq(Return(IntLit(1)), Assign("x", IntLit(2)))
+	s2 := Return(IntLit(1))
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestReturnVsAssignNotEquivalent(t *testing.T) {
+	ml := New()
+
+	// return 1 vs x = 1 should not be equivalent (different result kinds)
+	s1 := Return(IntLit(1))
+	s2 := Assign("x", IntLit(1))
+
+	report := ml.Verify(s1, s2)
+	if report.Result != NotEquivalent {
+		t.Errorf("Expected NotEquivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestBreakInLoop(t *testing.T) {
+	ml := NewForLoopContext()
+
+	// break vs break should be equivalent
+	s1 := Break()
+	s2 := Break()
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestContinueInLoop(t *testing.T) {
+	ml := NewForLoopContext()
+
+	// continue vs continue should be equivalent
+	s1 := ContinueS()
+	s2 := ContinueS()
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestBreakOutsideLoop(t *testing.T) {
+	ml := New() // Not in loop context
+
+	// break outside loop should return Unknown
+	s1 := Break()
+	s2 := Break()
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Unknown {
+		t.Errorf("Expected Unknown, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+// =======================
+// Early-Return Equivalence Tests
+// =======================
+
+func TestEarlyReturnRewrite(t *testing.T) {
+	ml := New()
+
+	// Original: if cond { return v } else { S }
+	// Rewritten: if cond { return v }; S
+	cond := BoolLit(true)
+	returnVal := IntLit(1)
+	elseStmt := Assign("x", IntLit(2))
+
+	report := ml.VerifyEarlyReturn(cond, returnVal, elseStmt)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestEarlyReturnRewriteFalseCondition(t *testing.T) {
+	ml := New()
+
+	// With false condition, both should execute the else/trailing statement
+	cond := BoolLit(false)
+	returnVal := IntLit(1)
+	elseStmt := Assign("x", IntLit(2))
+
+	report := ml.VerifyEarlyReturn(cond, returnVal, elseStmt)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestIfElseChainFlattening(t *testing.T) {
+	ml := New()
+
+	// if c1 { return v1 } else if c2 { return v2 } else { return v3 }
+	// =>
+	// if c1 { return v1 }; if c2 { return v2 }; return v3
+
+	conditions := []Expr{BoolLit(false), BoolLit(true)}
+	returns := []Expr{IntLit(1), IntLit(2)}
+	fallback := IntLit(3)
+
+	report := ml.VerifyIfElseChainFlattening(conditions, returns, fallback)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestNestedReturnEquivalence(t *testing.T) {
+	ml := New()
+
+	// if cond { if sub { return 1 } else { return 2 } } else { return 3 }
+	// With cond=true, sub=true: returns 1
+	cond := BoolLit(true)
+	sub := BoolLit(true)
+
+	s1 := If(cond, If(sub, Return(IntLit(1)), Return(IntLit(2))), Return(IntLit(3)))
+	s2 := If(cond, If(sub, Return(IntLit(1)), Return(IntLit(2))), Return(IntLit(3)))
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestIncompleteRewriteNotEquivalent(t *testing.T) {
+	ml := New()
+
+	// If one branch doesn't terminate, rewrite changes semantics
+	// Original: if true { x = 1 } else { return 2 }
+	// "Rewritten": if true { x = 1 }; return 2
+
+	// These are NOT equivalent because:
+	// - Original with true: x = 1, continues
+	// - Rewritten with true: x = 1, then return 2
+	original := If(BoolLit(true), Assign("x", IntLit(1)), Return(IntLit(2)))
+	rewritten := Seq(If(BoolLit(true), Assign("x", IntLit(1)), nil), Return(IntLit(2)))
+
+	report := ml.Verify(original, rewritten)
+	if report.Result != NotEquivalent {
+		t.Errorf("Expected NotEquivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+// =======================
+// Scoped Initializer Tests
+// =======================
+
+func TestInitializerEquivalence(t *testing.T) {
+	ml := New()
+
+	// if x := 1; x > 0 { return x } else { return 0 }
+	// Both branches return based on x, which is 1
+	s1 := IfInit(
+		DeclAssign("x", IntLit(1)),
+		Binary(OpGt, Var("x"), IntLit(0)),
+		Return(Var("x")),
+		Return(IntLit(0)),
+	)
+	s2 := IfInit(
+		DeclAssign("x", IntLit(1)),
+		Binary(OpGt, Var("x"), IntLit(0)),
+		Return(Var("x")),
+		Return(IntLit(0)),
+	)
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestShadowingInitVar(t *testing.T) {
+	ml := New()
+	env := NewEnv()
+	env.Set("x", IntValue{Val: 100}) // Outer x
+
+	// if x := 1; x > 0 { return x } else { return 0 }
+	// The inner x (1) shadows the outer x (100)
+	s := IfInit(
+		DeclAssign("x", IntLit(1)),
+		Binary(OpGt, Var("x"), IntLit(0)),
+		Return(Var("x")),
+		Return(IntLit(0)),
+	)
+
+	result := ml.Evaluate(s, env)
+	if result.Kind != ResultReturn {
+		t.Errorf("Expected Return, got %v", result.Kind)
+	}
+	if iv, ok := result.Value.(IntValue); !ok || iv.Val != 1 {
+		t.Errorf("Expected return value 1, got %v", result.Value)
+	}
+}
+
+func TestInitVarNotVisibleAfterIf(t *testing.T) {
+	ml := New()
+
+	// if x := 1; false {} should be equivalent to noop
+	// because x is not visible after the if statement
+	s1 := IfInit(
+		DeclAssign("x", IntLit(1)),
+		BoolLit(false),
+		Assign("y", IntLit(2)), // then branch (not taken)
+		nil,                    // no else
+	)
+	s2 := NoopStmt{}
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent (init var should not leak), got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestInitSideEffectsWithFalseNoElse(t *testing.T) {
+	ml := New()
+	env := NewEnv()
+	env.Set("y", IntValue{Val: 1})
+
+	// if y = 2; false {} should leave y updated to 2
+	s := IfInit(
+		Assign("y", IntLit(2)),
+		BoolLit(false),
+		NoopStmt{},
+		nil,
+	)
+
+	result := ml.Evaluate(s, env)
+	if result.Kind != ResultContinue {
+		t.Errorf("Expected Continue, got %v", result.Kind)
+	}
+	if yVal := result.Env.Get("y"); yVal == nil {
+		t.Error("y should be set")
+	} else if iv, ok := yVal.(IntValue); !ok || iv.Val != 2 {
+		t.Errorf("Expected y = 2, got %v", yVal)
+	}
+}
+
+func TestInitVarScopeWithTrueBranch(t *testing.T) {
+	ml := New()
+
+	// if x := 1; true { y = x } should assign y = 1
+	// but x should not be visible after the if
+	env := NewEnv()
+	s := IfInit(
+		DeclAssign("x", IntLit(1)),
+		BoolLit(true),
+		Assign("y", Var("x")),
+		nil,
+	)
+
+	result := ml.Evaluate(s, env)
+	if result.Kind != ResultContinue {
+		t.Errorf("Expected Continue, got %v", result.Kind)
+	}
+
+	// y should be set to 1
+	if yVal := result.Env.Get("y"); yVal == nil {
+		t.Error("y should be set")
+	} else if iv, ok := yVal.(IntValue); !ok || iv.Val != 1 {
+		t.Errorf("Expected y = 1, got %v", yVal)
+	}
+
+	// x should NOT be visible (init-scoped)
+	if xVal := result.Env.Get("x"); xVal != nil {
+		t.Errorf("x should not be visible after if, got %v", xVal)
+	}
+}
+
+func TestInitVarDoesNotAffectOuterScope(t *testing.T) {
+	ml := New()
+	env := NewEnv()
+	env.Set("x", IntValue{Val: 100}) // Outer x
+
+	// if x := 1; true { y = x } should not modify outer x
+	s := IfInit(
+		DeclAssign("x", IntLit(1)),
+		BoolLit(true),
+		Assign("y", Var("x")),
+		nil,
+	)
+
+	result := ml.Evaluate(s, env)
+	if result.Kind != ResultContinue {
+		t.Errorf("Expected Continue, got %v", result.Kind)
+	}
+
+	// Outer x should still be 100
+	if xVal := result.Env.Get("x"); xVal == nil {
+		t.Error("outer x should still exist")
+	} else if iv, ok := xVal.(IntValue); !ok || iv.Val != 100 {
+		t.Errorf("Expected outer x = 100, got %v", xVal)
+	}
+
+	// y should be 1 (from inner x)
+	if yVal := result.Env.Get("y"); yVal == nil {
+		t.Error("y should be set")
+	} else if iv, ok := yVal.(IntValue); !ok || iv.Val != 1 {
+		t.Errorf("Expected y = 1, got %v", yVal)
+	}
+}
+
+// =======================
+// Function Call Policy Tests
+// =======================
+
+func TestOpaqueCalls_SameOrder(t *testing.T) {
+	config := EvalConfig{
+		CallPolicy:      OpaqueCalls,
+		ControlFlowMode: EarlyReturnAware,
+	}
+	ml := NewWithConfig(config)
+
+	// f(); g() vs f(); g() should be equivalent
+	s1 := Seq(Call("f"), Call("g"))
+	s2 := Seq(Call("f"), Call("g"))
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestOpaqueCalls_DifferentOrder(t *testing.T) {
+	config := EvalConfig{
+		CallPolicy:      OpaqueCalls,
+		ControlFlowMode: EarlyReturnAware,
+	}
+	ml := NewWithConfig(config)
+
+	// f(); g() vs g(); f() should NOT be equivalent (different call order)
+	s1 := Seq(Call("f"), Call("g"))
+	s2 := Seq(Call("g"), Call("f"))
+
+	report := ml.Verify(s1, s2)
+	if report.Result != NotEquivalent {
+		t.Errorf("Expected NotEquivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestOpaqueCalls_InOneBranch(t *testing.T) {
+	config := EvalConfig{
+		CallPolicy:      OpaqueCalls,
+		ControlFlowMode: EarlyReturnAware,
+	}
+	ml := NewWithConfig(config)
+
+	// if true { f() } else { } vs f() should be equivalent
+	s1 := If(BoolLit(true), Call("f"), NoopStmt{})
+	s2 := Call("f")
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Equivalent {
+		t.Errorf("Expected Equivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestDisallowCalls(t *testing.T) {
+	config := EvalConfig{
+		CallPolicy:      DisallowCalls,
+		ControlFlowMode: EarlyReturnAware,
+	}
+	ml := NewWithConfig(config)
+
+	// Any call should result in Unknown
+	s1 := Call("f")
+	s2 := Call("f")
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Unknown {
+		t.Errorf("Expected Unknown, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestDisallowCallsInExpr(t *testing.T) {
+	config := EvalConfig{
+		CallPolicy:      DisallowCalls,
+		ControlFlowMode: EarlyReturnAware,
+	}
+	ml := NewWithConfig(config)
+
+	// Calls inside expressions should also result in Unknown
+	s1 := Assign("x", CallExpr{Func: "f"})
+	s2 := Assign("x", CallExpr{Func: "f"})
+
+	report := ml.Verify(s1, s2)
+	if report.Result != Unknown {
+		t.Errorf("Expected Unknown, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+// =======================
+// API Tests
+// =======================
+
+func TestBatchVerify(t *testing.T) {
+	ml := New()
+
+	transformations := []TransformationContext{
+		{
+			Original:    Assign("x", IntLit(1)),
+			Transformed: Assign("x", IntLit(1)),
+			RuleName:    "test1",
+		},
+		{
+			Original:    Assign("x", IntLit(1)),
+			Transformed: Assign("x", IntLit(2)),
+			RuleName:    "test2",
+		},
+		{
+			Original:    Return(IntLit(1)),
+			Transformed: Return(IntLit(1)),
+			RuleName:    "test3",
+		},
+	}
+
+	report := ml.BatchVerify(transformations)
+
+	if report.Total != 3 {
+		t.Errorf("Expected 3 total, got %d", report.Total)
+	}
+	if report.Equivalent != 2 {
+		t.Errorf("Expected 2 equivalent, got %d", report.Equivalent)
+	}
+	if report.NotEquivalent != 1 {
+		t.Errorf("Expected 1 not equivalent, got %d", report.NotEquivalent)
+	}
+}
+
+func TestSafetyHelpers(t *testing.T) {
+	equiv := VerificationReport{Result: Equivalent}
+	notEquiv := VerificationReport{Result: NotEquivalent}
+	unknown := VerificationReport{Result: Unknown}
+
+	if !IsSafeToApply(equiv) {
+		t.Error("IsSafeToApply should return true for Equivalent")
+	}
+	if IsSafeToApply(notEquiv) {
+		t.Error("IsSafeToApply should return false for NotEquivalent")
+	}
+	if IsSafeToApply(unknown) {
+		t.Error("IsSafeToApply should return false for Unknown")
+	}
+
+	if ShouldWarn(equiv) {
+		t.Error("ShouldWarn should return false for Equivalent")
+	}
+	if ShouldWarn(notEquiv) {
+		t.Error("ShouldWarn should return false for NotEquivalent")
+	}
+	if !ShouldWarn(unknown) {
+		t.Error("ShouldWarn should return true for Unknown")
+	}
+
+	if IsDefinitelyUnsafe(equiv) {
+		t.Error("IsDefinitelyUnsafe should return false for Equivalent")
+	}
+	if !IsDefinitelyUnsafe(notEquiv) {
+		t.Error("IsDefinitelyUnsafe should return true for NotEquivalent")
+	}
+	if IsDefinitelyUnsafe(unknown) {
+		t.Error("IsDefinitelyUnsafe should return false for Unknown")
+	}
+}
+
+// =======================
+// Normalization Tests
+// =======================
+
+func TestNormalize_ConstantFolding(t *testing.T) {
+	ml := New()
+
+	// x = 1 + 2 should normalize to x = 3
+	s := Assign("x", Binary(OpAdd, IntLit(1), IntLit(2)))
+	normalized := ml.Normalize(s)
+
+	if assign, ok := normalized.(AssignStmt); ok {
+		if lit, ok := assign.Expr.(LiteralExpr); ok {
+			if iv, ok := lit.Val.(IntValue); ok {
+				if iv.Val != 3 {
+					t.Errorf("Expected 3, got %d", iv.Val)
+				}
+			} else {
+				t.Errorf("Expected IntValue, got %T", lit.Val)
+			}
+		} else {
+			t.Errorf("Expected LiteralExpr, got %T", assign.Expr)
+		}
+	} else {
+		t.Errorf("Expected AssignStmt, got %T", normalized)
+	}
+}
+
+func TestNormalize_DoubleNegation(t *testing.T) {
+	ml := New()
+
+	// !!x should normalize to x
+	s := Assign("result", Not(Not(Var("x"))))
+	normalized := ml.Normalize(s)
+
+	if assign, ok := normalized.(AssignStmt); ok {
+		if v, ok := assign.Expr.(VarExpr); ok {
+			if v.Name != "x" {
+				t.Errorf("Expected variable x, got %s", v.Name)
+			}
+		} else {
+			t.Errorf("Expected VarExpr after double negation elimination, got %T", assign.Expr)
+		}
+	}
+}
+
+func TestNormalize_BooleanSimplification(t *testing.T) {
+	ml := New()
+
+	// true && x should normalize to x
+	s := Assign("result", And(BoolLit(true), Var("x")))
+	normalized := ml.Normalize(s)
+
+	if assign, ok := normalized.(AssignStmt); ok {
+		if v, ok := assign.Expr.(VarExpr); ok {
+			if v.Name != "x" {
+				t.Errorf("Expected variable x, got %s", v.Name)
+			}
+		} else {
+			t.Errorf("Expected VarExpr, got %T", assign.Expr)
+		}
+	}
+}
+
+func TestFlattenIfElseChain(t *testing.T) {
+	ml := New()
+
+	// if c1 { return 1 } else { if c2 { return 2 } else { return 3 } }
+	original := If(
+		Var("c1"),
+		Return(IntLit(1)),
+		If(
+			Var("c2"),
+			Return(IntLit(2)),
+			Return(IntLit(3)),
+		),
+	)
+
+	flattened := ml.FlattenIfElseChain(original)
+
+	// Should be: if c1 { return 1 }; if c2 { return 2 }; return 3
+	// Verify it's a sequence
+	if _, ok := flattened.(SeqStmt); !ok {
+		t.Errorf("Expected SeqStmt, got %T", flattened)
+	}
+}
+
+// =======================
+// Environment Tests
+// =======================
+
+func TestEnv_BasicOperations(t *testing.T) {
+	env := NewEnv()
+
+	// Test Set and Get
+	env.Set("x", IntValue{Val: 42})
+	val := env.Get("x")
+	if iv, ok := val.(IntValue); !ok || iv.Val != 42 {
+		t.Errorf("Expected 42, got %v", val)
+	}
+
+	// Test Get non-existent
+	val = env.Get("y")
+	if val != nil {
+		t.Errorf("Expected nil for non-existent var, got %v", val)
+	}
+}
+
+func TestEnv_Clone(t *testing.T) {
+	env := NewEnv()
+	env.Set("x", IntValue{Val: 1})
+
+	clone := env.Clone()
+	clone.Set("x", IntValue{Val: 2})
+
+	// Original should be unchanged
+	if iv, ok := env.Get("x").(IntValue); !ok || iv.Val != 1 {
+		t.Errorf("Original env was modified")
+	}
+
+	// Clone should have new value
+	if iv, ok := clone.Get("x").(IntValue); !ok || iv.Val != 2 {
+		t.Errorf("Clone should have new value")
+	}
+}
+
+func TestEnv_ChildScope(t *testing.T) {
+	parent := NewEnv()
+	parent.Set("x", IntValue{Val: 1})
+
+	child := NewChildEnv(parent)
+	child.Set("y", IntValue{Val: 2})
+
+	// Child can see parent's variable
+	if iv, ok := child.Get("x").(IntValue); !ok || iv.Val != 1 {
+		t.Errorf("Child should see parent's x")
+	}
+
+	// Child has its own variable
+	if iv, ok := child.Get("y").(IntValue); !ok || iv.Val != 2 {
+		t.Errorf("Child should have y")
+	}
+
+	// Parent doesn't see child's variable
+	if parent.Get("y") != nil {
+		t.Errorf("Parent should not see child's y")
+	}
+
+	// Shadowing
+	child.Set("x", IntValue{Val: 100})
+	if iv, ok := child.Get("x").(IntValue); !ok || iv.Val != 100 {
+		t.Errorf("Child should shadow parent's x")
+	}
+	if iv, ok := parent.Get("x").(IntValue); !ok || iv.Val != 1 {
+		t.Errorf("Parent's x should be unchanged")
+	}
+}
+
+func TestEnv_Equality(t *testing.T) {
+	env1 := NewEnv()
+	env1.Set("x", IntValue{Val: 1})
+	env1.Set("y", IntValue{Val: 2})
+
+	env2 := NewEnv()
+	env2.Set("x", IntValue{Val: 1})
+	env2.Set("y", IntValue{Val: 2})
+
+	if !env1.Equal(env2) {
+		t.Error("Environments with same bindings should be equal")
+	}
+
+	env2.Set("y", IntValue{Val: 3})
+	if env1.Equal(env2) {
+		t.Error("Environments with different bindings should not be equal")
+	}
+}
+
+// =======================
+// Value Tests
+// =======================
+
+func TestValue_Equality(t *testing.T) {
+	tests := []struct {
+		a, b  Value
+		equal bool
+	}{
+		{IntValue{Val: 1}, IntValue{Val: 1}, true},
+		{IntValue{Val: 1}, IntValue{Val: 2}, false},
+		{BoolValue{Val: true}, BoolValue{Val: true}, true},
+		{BoolValue{Val: true}, BoolValue{Val: false}, false},
+		{StringValue{Val: "hello"}, StringValue{Val: "hello"}, true},
+		{StringValue{Val: "hello"}, StringValue{Val: "world"}, false},
+		{NilValue{}, NilValue{}, true},
+		{IntValue{Val: 1}, BoolValue{Val: true}, false},
+		{SymbolicValue{Name: "x"}, SymbolicValue{Name: "x"}, true},
+		{SymbolicValue{Name: "x"}, SymbolicValue{Name: "y"}, false},
+	}
+
+	for _, tt := range tests {
+		got := tt.a.Equal(tt.b)
+		if got != tt.equal {
+			t.Errorf("%v.Equal(%v) = %v, want %v", tt.a, tt.b, got, tt.equal)
+		}
+	}
+}
+
+// =======================
+// Result Tests
+// =======================
+
+func TestResult_Equality(t *testing.T) {
+	env1 := NewEnv()
+	env1.Set("x", IntValue{Val: 1})
+
+	env2 := NewEnv()
+	env2.Set("x", IntValue{Val: 1})
+
+	tests := []struct {
+		a, b  Result
+		equal bool
+	}{
+		{ContinueResult(env1), ContinueResult(env2), true},
+		{ReturnResult(IntValue{Val: 1}, nil), ReturnResult(IntValue{Val: 1}, nil), true},
+		{ReturnResult(IntValue{Val: 1}, nil), ReturnResult(IntValue{Val: 2}, nil), false},
+		{BreakResult(nil), BreakResult(nil), true},
+		{ContinueLoopResult(nil), ContinueLoopResult(nil), true},
+		{BreakResult(nil), ContinueLoopResult(nil), false},
+	}
+
+	for _, tt := range tests {
+		got := tt.a.Equal(tt.b)
+		if got != tt.equal {
+			t.Errorf("%v.Equal(%v) = %v, want %v", tt.a, tt.b, got, tt.equal)
+		}
+	}
+}
+
+// =======================
+// Regression Tests
+// =======================
+
+func TestRegression_EarlyReturnWithElseStatements(t *testing.T) {
+	ml := New()
+
+	// This is a key pattern for early-return lint rules:
+	// if err != nil { return err } else { doSomething() }
+	// should be equivalent to:
+	// if err != nil { return err }; doSomething()
+
+	// Test with condition = true (return path)
+	original := If(BoolLit(true), Return(IntLit(1)), Assign("x", IntLit(2)))
+	rewritten := Seq(If(BoolLit(true), Return(IntLit(1)), nil), Assign("x", IntLit(2)))
+
+	report := ml.Verify(original, rewritten)
+	if report.Result != Equivalent {
+		t.Errorf("Early return pattern should be equivalent (true case), got %v: %s", report.Result, report.Detail)
+	}
+
+	// Test with condition = false (else path)
+	original = If(BoolLit(false), Return(IntLit(1)), Assign("x", IntLit(2)))
+	rewritten = Seq(If(BoolLit(false), Return(IntLit(1)), nil), Assign("x", IntLit(2)))
+
+	report = ml.Verify(original, rewritten)
+	if report.Result != Equivalent {
+		t.Errorf("Early return pattern should be equivalent (false case), got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestRegression_LongSequence(t *testing.T) {
+	ml := New()
+
+	// Test a long sequence of early-return blocks
+	// if c1 { return 1 }; if c2 { return 2 }; if c3 { return 3 }; return 4
+	s1 := Seq(
+		If(BoolLit(false), Return(IntLit(1)), nil),
+		Seq(
+			If(BoolLit(false), Return(IntLit(2)), nil),
+			Seq(
+				If(BoolLit(true), Return(IntLit(3)), nil),
+				Return(IntLit(4)),
+			),
+		),
+	)
+
+	// This should return 3 (third condition is true)
+	result := ml.Evaluate(s1, NewEnv())
+	if result.Kind != ResultReturn {
+		t.Errorf("Expected Return, got %v", result.Kind)
+	}
+	if iv, ok := result.Value.(IntValue); !ok || iv.Val != 3 {
+		t.Errorf("Expected return value 3, got %v", result.Value)
+	}
+}

--- a/internal/minilogic/minilogic_test.go
+++ b/internal/minilogic/minilogic_test.go
@@ -44,6 +44,8 @@ func TestDebugIRReport(t *testing.T) {
 	s2 := Assign("x", IntLit(1))
 
 	report := ml.Verify(s1, s2)
+	t.Log(report.IR.Original)
+	t.Log(report.IR.Transformed)
 	if report.IR == nil {
 		t.Fatal("Expected debug IR report to be populated")
 	}

--- a/internal/minilogic/minilogic_test.go
+++ b/internal/minilogic/minilogic_test.go
@@ -98,7 +98,6 @@ func TestDebugIRComplexCase(t *testing.T) {
 	t.Logf("original:\n%s", report.IR.Original)
 	t.Logf("transformed:\n%s", report.IR.Transformed)
 	t.Logf("details:\n%s", report.Detail)
-
 }
 
 func TestAssignmentNotEquivalent(t *testing.T) {
@@ -548,6 +547,22 @@ func TestOpaqueCalls_DifferentOrder(t *testing.T) {
 	// f(); g() vs g(); f() should NOT be equivalent (different call order)
 	s1 := Seq(Call("f"), Call("g"))
 	s2 := Seq(Call("g"), Call("f"))
+
+	report := ml.Verify(s1, s2)
+	if report.Result != NotEquivalent {
+		t.Errorf("Expected NotEquivalent, got %v: %s", report.Result, report.Detail)
+	}
+}
+
+func TestOpaqueCalls_DifferentOrderInExpr(t *testing.T) {
+	config := EvalConfig{
+		CallPolicy:      OpaqueCalls,
+		ControlFlowMode: EarlyReturnAware,
+	}
+	ml := NewWithConfig(config)
+
+	s1 := Assign("x", Binary(OpAdd, CallExpr{Func: "f"}, CallExpr{Func: "g"}))
+	s2 := Assign("x", Binary(OpAdd, CallExpr{Func: "g"}, CallExpr{Func: "f"}))
 
 	report := ml.Verify(s1, s2)
 	if report.Result != NotEquivalent {

--- a/internal/minilogic/normalize.go
+++ b/internal/minilogic/normalize.go
@@ -1,0 +1,466 @@
+package minilogic
+
+// Normalizer transforms statements into canonical forms for equivalence checking.
+type Normalizer struct {
+	config EvalConfig
+}
+
+// NewNormalizer creates a new normalizer.
+func NewNormalizer(config EvalConfig) *Normalizer {
+	return &Normalizer{config: config}
+}
+
+// Normalize transforms a statement into its canonical form.
+// This helps detect structural equivalence between different syntactic forms.
+func (n *Normalizer) Normalize(stmt Stmt) Stmt {
+	return n.normalizeStmt(stmt)
+}
+
+func (n *Normalizer) normalizeStmt(stmt Stmt) Stmt {
+	switch s := stmt.(type) {
+	case AssignStmt:
+		return AssignStmt{Var: s.Var, Expr: n.normalizeExpr(s.Expr)}
+
+	case DeclAssignStmt:
+		return DeclAssignStmt{Var: s.Var, Expr: n.normalizeExpr(s.Expr)}
+
+	case SeqStmt:
+		first := n.normalizeStmt(s.First)
+		second := n.normalizeStmt(s.Second)
+
+		// If first is a no-op, return second
+		if _, ok := first.(NoopStmt); ok {
+			return second
+		}
+
+		// If second is a no-op, return first
+		if _, ok := second.(NoopStmt); ok {
+			return first
+		}
+
+		return SeqStmt{First: first, Second: second}
+
+	case BlockStmt:
+		normalized := make([]Stmt, 0, len(s.Stmts))
+		for _, st := range s.Stmts {
+			norm := n.normalizeStmt(st)
+			if _, ok := norm.(NoopStmt); !ok {
+				normalized = append(normalized, norm)
+			}
+		}
+		if len(normalized) == 0 {
+			return NoopStmt{}
+		}
+		if len(normalized) == 1 {
+			return normalized[0]
+		}
+		return BlockStmt{Stmts: normalized}
+
+	case IfStmt:
+		return n.normalizeIf(s)
+
+	case ReturnStmt:
+		if s.Value != nil {
+			return ReturnStmt{Value: n.normalizeExpr(s.Value)}
+		}
+		return s
+
+	case BreakStmt, ContinueStmt, NoopStmt:
+		return s
+
+	case CallStmt:
+		return CallStmt{Call: n.normalizeCallExpr(s.Call)}
+
+	default:
+		return stmt
+	}
+}
+
+func (n *Normalizer) normalizeIf(s IfStmt) Stmt {
+	var init Stmt
+	if s.Init != nil {
+		init = n.normalizeStmt(s.Init)
+	}
+
+	cond := n.normalizeExpr(s.Cond)
+	then := n.normalizeStmt(s.Then)
+
+	var els Stmt
+	if s.Else != nil {
+		els = n.normalizeStmt(s.Else)
+	}
+
+	// Constant folding for conditions
+	if lit, ok := cond.(LiteralExpr); ok {
+		if b, ok := lit.Val.(BoolValue); ok {
+			if b.Val {
+				// if true { S1 } else { S2 } => S1
+				if init != nil {
+					return SeqStmt{First: init, Second: then}
+				}
+				return then
+			}
+			// if false { S1 } else { S2 } => S2
+			if els != nil {
+				if init != nil {
+					return SeqStmt{First: init, Second: els}
+				}
+				return els
+			}
+			// if false { S1 } => noop
+			if init != nil {
+				return init
+			}
+			return NoopStmt{}
+		}
+	}
+
+	return IfStmt{Init: init, Cond: cond, Then: then, Else: els}
+}
+
+func (n *Normalizer) normalizeExpr(expr Expr) Expr {
+	switch e := expr.(type) {
+	case LiteralExpr:
+		return e
+
+	case VarExpr:
+		return e
+
+	case BinaryExpr:
+		left := n.normalizeExpr(e.Left)
+		right := n.normalizeExpr(e.Right)
+
+		// Constant folding
+		if llit, lok := left.(LiteralExpr); lok {
+			if rlit, rok := right.(LiteralExpr); rok {
+				if result := n.evalConstBinary(e.Op, llit.Val, rlit.Val); result != nil {
+					return LiteralExpr{Val: result}
+				}
+			}
+		}
+
+		// Boolean simplifications
+		if e.Op == OpAnd {
+			// false && x => false
+			if llit, ok := left.(LiteralExpr); ok {
+				if b, ok := llit.Val.(BoolValue); ok && !b.Val {
+					return LiteralExpr{Val: BoolValue{Val: false}}
+				}
+			}
+			// x && false => false
+			if rlit, ok := right.(LiteralExpr); ok {
+				if b, ok := rlit.Val.(BoolValue); ok && !b.Val {
+					return LiteralExpr{Val: BoolValue{Val: false}}
+				}
+			}
+			// true && x => x
+			if llit, ok := left.(LiteralExpr); ok {
+				if b, ok := llit.Val.(BoolValue); ok && b.Val {
+					return right
+				}
+			}
+			// x && true => x
+			if rlit, ok := right.(LiteralExpr); ok {
+				if b, ok := rlit.Val.(BoolValue); ok && b.Val {
+					return left
+				}
+			}
+		}
+
+		if e.Op == OpOr {
+			// true || x => true
+			if llit, ok := left.(LiteralExpr); ok {
+				if b, ok := llit.Val.(BoolValue); ok && b.Val {
+					return LiteralExpr{Val: BoolValue{Val: true}}
+				}
+			}
+			// x || true => true
+			if rlit, ok := right.(LiteralExpr); ok {
+				if b, ok := rlit.Val.(BoolValue); ok && b.Val {
+					return LiteralExpr{Val: BoolValue{Val: true}}
+				}
+			}
+			// false || x => x
+			if llit, ok := left.(LiteralExpr); ok {
+				if b, ok := llit.Val.(BoolValue); ok && !b.Val {
+					return right
+				}
+			}
+			// x || false => x
+			if rlit, ok := right.(LiteralExpr); ok {
+				if b, ok := rlit.Val.(BoolValue); ok && !b.Val {
+					return left
+				}
+			}
+		}
+
+		return BinaryExpr{Op: e.Op, Left: left, Right: right}
+
+	case UnaryExpr:
+		operand := n.normalizeExpr(e.Operand)
+
+		// Constant folding
+		if lit, ok := operand.(LiteralExpr); ok {
+			if result := n.evalConstUnary(e.Op, lit.Val); result != nil {
+				return LiteralExpr{Val: result}
+			}
+		}
+
+		// Double negation elimination
+		if e.Op == OpNot {
+			if inner, ok := operand.(UnaryExpr); ok && inner.Op == OpNot {
+				return inner.Operand
+			}
+		}
+
+		return UnaryExpr{Op: e.Op, Operand: operand}
+
+	case CallExpr:
+		return n.normalizeCallExpr(&e)
+
+	default:
+		return expr
+	}
+}
+
+func (n *Normalizer) normalizeCallExpr(c *CallExpr) *CallExpr {
+	args := make([]Expr, len(c.Args))
+	for i, arg := range c.Args {
+		args[i] = n.normalizeExpr(arg)
+	}
+	return &CallExpr{Func: c.Func, Args: args}
+}
+
+func (n *Normalizer) evalConstBinary(op BinaryOp, left, right Value) Value {
+	switch op {
+	case OpAdd:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				return IntValue{Val: l.Val + r.Val}
+			}
+		}
+	case OpSub:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				return IntValue{Val: l.Val - r.Val}
+			}
+		}
+	case OpMul:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				return IntValue{Val: l.Val * r.Val}
+			}
+		}
+	case OpDiv:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				if r.Val != 0 {
+					return IntValue{Val: l.Val / r.Val}
+				}
+			}
+		}
+	case OpMod:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				if r.Val != 0 {
+					return IntValue{Val: l.Val % r.Val}
+				}
+			}
+		}
+	case OpEq:
+		return BoolValue{Val: left.Equal(right)}
+	case OpNeq:
+		return BoolValue{Val: !left.Equal(right)}
+	case OpLt:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				return BoolValue{Val: l.Val < r.Val}
+			}
+		}
+	case OpLte:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				return BoolValue{Val: l.Val <= r.Val}
+			}
+		}
+	case OpGt:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				return BoolValue{Val: l.Val > r.Val}
+			}
+		}
+	case OpGte:
+		if l, ok := left.(IntValue); ok {
+			if r, ok := right.(IntValue); ok {
+				return BoolValue{Val: l.Val >= r.Val}
+			}
+		}
+	case OpAnd:
+		if l, ok := left.(BoolValue); ok {
+			if r, ok := right.(BoolValue); ok {
+				return BoolValue{Val: l.Val && r.Val}
+			}
+		}
+	case OpOr:
+		if l, ok := left.(BoolValue); ok {
+			if r, ok := right.(BoolValue); ok {
+				return BoolValue{Val: l.Val || r.Val}
+			}
+		}
+	}
+	return nil
+}
+
+func (n *Normalizer) evalConstUnary(op UnaryOp, operand Value) Value {
+	switch op {
+	case OpNot:
+		if b, ok := operand.(BoolValue); ok {
+			return BoolValue{Val: !b.Val}
+		}
+	case OpNeg:
+		if i, ok := operand.(IntValue); ok {
+			return IntValue{Val: -i.Val}
+		}
+	}
+	return nil
+}
+
+// FlattenIfElseChain flattens a nested if-else chain into a sequence.
+// This is the canonical transformation for early-return patterns.
+//
+// Input:
+//
+//	if c1 { return v1 }
+//	else if c2 { return v2 }
+//	else { S }
+//
+// Output:
+//
+//	if c1 { return v1 }
+//	if c2 { return v2 }
+//	S
+func (n *Normalizer) FlattenIfElseChain(stmt Stmt) Stmt {
+	ifStmt, ok := stmt.(IfStmt)
+	if !ok {
+		return stmt
+	}
+
+	// Check if then branch terminates
+	if !n.branchTerminates(ifStmt.Then) {
+		return stmt
+	}
+
+	// Build flattened sequence
+	var result []Stmt
+
+	// Add the initial if (without else)
+	result = append(result, IfStmt{
+		Init: ifStmt.Init,
+		Cond: ifStmt.Cond,
+		Then: ifStmt.Then,
+		Else: nil,
+	})
+
+	// Process the else branch
+	current := ifStmt.Else
+	for current != nil {
+		if nested, ok := current.(IfStmt); ok {
+			if n.branchTerminates(nested.Then) {
+				result = append(result, IfStmt{
+					Init: nested.Init,
+					Cond: nested.Cond,
+					Then: nested.Then,
+					Else: nil,
+				})
+				current = nested.Else
+			} else {
+				// Non-terminating then branch, stop flattening
+				result = append(result, current)
+				break
+			}
+		} else {
+			// Not an if statement, add as final statement
+			result = append(result, current)
+			break
+		}
+	}
+
+	return Seq(result...)
+}
+
+// branchTerminates checks if a statement definitely terminates (return, break, continue).
+func (n *Normalizer) branchTerminates(stmt Stmt) bool {
+	switch s := stmt.(type) {
+	case ReturnStmt, BreakStmt, ContinueStmt:
+		return true
+
+	case BlockStmt:
+		if len(s.Stmts) == 0 {
+			return false
+		}
+		return n.branchTerminates(s.Stmts[len(s.Stmts)-1])
+
+	case SeqStmt:
+		// Check if any statement in the sequence terminates
+		if n.branchTerminates(s.First) {
+			return true
+		}
+		return n.branchTerminates(s.Second)
+
+	case IfStmt:
+		// If terminates if both branches terminate
+		thenTerms := n.branchTerminates(s.Then)
+		elseTerms := s.Else != nil && n.branchTerminates(s.Else)
+		return thenTerms && elseTerms
+
+	default:
+		return false
+	}
+}
+
+// UnflattenToIfElseChain converts a flat sequence back to nested if-else.
+// This is the inverse of FlattenIfElseChain.
+func (n *Normalizer) UnflattenToIfElseChain(stmt Stmt) Stmt {
+	stmts := n.collectSequence(stmt)
+	if len(stmts) == 0 {
+		return NoopStmt{}
+	}
+
+	// Build nested if-else from the end
+	result := stmts[len(stmts)-1]
+	for i := len(stmts) - 2; i >= 0; i-- {
+		if ifStmt, ok := stmts[i].(IfStmt); ok && ifStmt.Else == nil {
+			result = IfStmt{
+				Init: ifStmt.Init,
+				Cond: ifStmt.Cond,
+				Then: ifStmt.Then,
+				Else: result,
+			}
+		} else {
+			// Not an if statement or has else, cannot unflatten
+			result = SeqStmt{First: stmts[i], Second: result}
+		}
+	}
+
+	return result
+}
+
+func (n *Normalizer) collectSequence(stmt Stmt) []Stmt {
+	var result []Stmt
+	n.collectSeqHelper(stmt, &result)
+	return result
+}
+
+func (n *Normalizer) collectSeqHelper(stmt Stmt, result *[]Stmt) {
+	switch s := stmt.(type) {
+	case SeqStmt:
+		n.collectSeqHelper(s.First, result)
+		n.collectSeqHelper(s.Second, result)
+	case BlockStmt:
+		for _, st := range s.Stmts {
+			*result = append(*result, st)
+		}
+	default:
+		*result = append(*result, stmt)
+	}
+}

--- a/internal/minilogic/normalize.go
+++ b/internal/minilogic/normalize.go
@@ -24,6 +24,15 @@ func (n *Normalizer) normalizeStmt(stmt Stmt) Stmt {
 	case DeclAssignStmt:
 		return DeclAssignStmt{Var: s.Var, Expr: n.normalizeExpr(s.Expr)}
 
+	case DeclAssignMultiStmt:
+		return DeclAssignMultiStmt{Vars: s.Vars, Expr: n.normalizeExpr(s.Expr)}
+
+	case VarDeclStmt:
+		if s.Expr != nil {
+			return VarDeclStmt{Var: s.Var, Expr: n.normalizeExpr(s.Expr)}
+		}
+		return s
+
 	case SeqStmt:
 		first := n.normalizeStmt(s.First)
 		second := n.normalizeStmt(s.Second)

--- a/internal/minilogic/result.go
+++ b/internal/minilogic/result.go
@@ -1,0 +1,177 @@
+package minilogic
+
+import "fmt"
+
+// ResultKind represents the kind of execution result.
+type ResultKind int
+
+const (
+	// ResultContinue indicates normal execution continues.
+	ResultContinue ResultKind = iota
+	// ResultReturn indicates a return statement was executed.
+	ResultReturn
+	// ResultBreak indicates a break statement was executed.
+	ResultBreak
+	// ResultContinueLoop indicates a continue statement was executed.
+	ResultContinueLoop
+	// ResultUnknown indicates the result cannot be determined.
+	ResultUnknown
+)
+
+func (k ResultKind) String() string {
+	switch k {
+	case ResultContinue:
+		return "Continue"
+	case ResultReturn:
+		return "Return"
+	case ResultBreak:
+		return "Break"
+	case ResultContinueLoop:
+		return "ContinueLoop"
+	case ResultUnknown:
+		return "Unknown"
+	default:
+		return "?"
+	}
+}
+
+// Result represents the outcome of evaluating a statement.
+// Based on MiniLogic v2.1 spec:
+// Result = Continue(Env) | Return(Value?) | Break | ContinueLoop | Unknown
+type Result struct {
+	Kind  ResultKind
+	Env   *Env         // valid for Continue
+	Value Value        // valid for Return (can be nil)
+	Calls []CallRecord // tracked function calls (for OpaqueCalls policy)
+}
+
+// CallRecord represents a function call that was executed.
+type CallRecord struct {
+	Func string
+	Args []Value
+}
+
+func (c CallRecord) String() string {
+	result := c.Func + "("
+	for i, arg := range c.Args {
+		if i > 0 {
+			result += ", "
+		}
+		result += arg.String()
+	}
+	return result + ")"
+}
+
+// ContinueResult creates a Continue result with the given environment.
+func ContinueResult(env *Env) Result {
+	return Result{Kind: ResultContinue, Env: env}
+}
+
+// ContinueResultWithCalls creates a Continue result with tracked calls.
+func ContinueResultWithCalls(env *Env, calls []CallRecord) Result {
+	return Result{Kind: ResultContinue, Env: env, Calls: calls}
+}
+
+// ReturnResult creates a Return result with the given value.
+func ReturnResult(val Value, calls []CallRecord) Result {
+	return Result{Kind: ResultReturn, Value: val, Calls: calls}
+}
+
+// ReturnNilResult creates a Return result with nil value.
+func ReturnNilResult(calls []CallRecord) Result {
+	return Result{Kind: ResultReturn, Value: NilValue{}, Calls: calls}
+}
+
+// BreakResult creates a Break result.
+func BreakResult(calls []CallRecord) Result {
+	return Result{Kind: ResultBreak, Calls: calls}
+}
+
+// ContinueLoopResult creates a ContinueLoop result.
+func ContinueLoopResult(calls []CallRecord) Result {
+	return Result{Kind: ResultContinueLoop, Calls: calls}
+}
+
+// UnknownResult creates an Unknown result.
+func UnknownResult() Result {
+	return Result{Kind: ResultUnknown}
+}
+
+// IsTerminating returns true if this result represents a terminating statement.
+func (r Result) IsTerminating() bool {
+	return r.Kind == ResultReturn || r.Kind == ResultBreak || r.Kind == ResultContinueLoop
+}
+
+// String returns a string representation of the result.
+func (r Result) String() string {
+	switch r.Kind {
+	case ResultContinue:
+		return fmt.Sprintf("Continue(%s)", r.Env.String())
+	case ResultReturn:
+		if r.Value == nil {
+			return "Return(nil)"
+		}
+		return fmt.Sprintf("Return(%s)", r.Value.String())
+	case ResultBreak:
+		return "Break"
+	case ResultContinueLoop:
+		return "ContinueLoop"
+	case ResultUnknown:
+		return "Unknown"
+	default:
+		return "?"
+	}
+}
+
+// Equal checks if two results are equivalent.
+func (r Result) Equal(other Result) bool {
+	if r.Kind != other.Kind {
+		return false
+	}
+
+	switch r.Kind {
+	case ResultContinue:
+		// Environments must be equal
+		if !r.Env.Equal(other.Env) {
+			return false
+		}
+	case ResultReturn:
+		// Returned values must be equal
+		if r.Value == nil && other.Value == nil {
+			// both nil
+		} else if r.Value == nil || other.Value == nil {
+			return false
+		} else if !r.Value.Equal(other.Value) {
+			return false
+		}
+	case ResultBreak, ResultContinueLoop, ResultUnknown:
+		// Kind match is sufficient
+	}
+
+	// Check call sequence equality
+	if len(r.Calls) != len(other.Calls) {
+		return false
+	}
+	for i := range r.Calls {
+		if !callsEqual(r.Calls[i], other.Calls[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func callsEqual(a, b CallRecord) bool {
+	if a.Func != b.Func {
+		return false
+	}
+	if len(a.Args) != len(b.Args) {
+		return false
+	}
+	for i := range a.Args {
+		if !a.Args[i].Equal(b.Args[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/minilogic/result.go
+++ b/internal/minilogic/result.go
@@ -6,8 +6,9 @@ import "fmt"
 type ResultKind int
 
 const (
+	_ ResultKind = iota
 	// ResultContinue indicates normal execution continues.
-	ResultContinue ResultKind = iota
+	ResultContinue
 	// ResultReturn indicates a return statement was executed.
 	ResultReturn
 	// ResultBreak indicates a break statement was executed.

--- a/internal/minilogic/symbolic.go
+++ b/internal/minilogic/symbolic.go
@@ -1,0 +1,96 @@
+package minilogic
+
+// CondSolver attempts to resolve a condition to a concrete boolean.
+// It can be backed by a symbolic engine or SMT solver.
+type CondSolver interface {
+	Solve(cond Expr, env *Env) (BoolValue, bool)
+}
+
+// BasicCondSolver provides simple, sound condition deductions.
+type BasicCondSolver struct{}
+
+func (BasicCondSolver) Solve(cond Expr, env *Env) (BoolValue, bool) {
+	if exprHasCall(cond) {
+		return BoolValue{}, false
+	}
+
+	switch c := cond.(type) {
+	case LiteralExpr:
+		if b, ok := c.Val.(BoolValue); ok {
+			return b, true
+		}
+	case VarExpr:
+		if val := env.Get(c.Name); val != nil {
+			if b, ok := val.(BoolValue); ok {
+				return b, true
+			}
+		}
+	case UnaryExpr:
+		if c.Op == OpNot {
+			solver := BasicCondSolver{}
+			if v, ok := solver.Solve(c.Operand, env); ok {
+				return BoolValue{Val: !v.Val}, true
+			}
+		}
+	case BinaryExpr:
+		switch c.Op {
+		case OpEq, OpNeq:
+			if exprEqual(c.Left, c.Right) {
+				return BoolValue{Val: c.Op == OpEq}, true
+			}
+		}
+	}
+
+	return BoolValue{}, false
+}
+
+func exprEqual(a, b Expr) bool {
+	switch left := a.(type) {
+	case LiteralExpr:
+		right, ok := b.(LiteralExpr)
+		if !ok {
+			return false
+		}
+		return left.Val.Equal(right.Val)
+	case VarExpr:
+		right, ok := b.(VarExpr)
+		if !ok {
+			return false
+		}
+		return left.Name == right.Name
+	case BinaryExpr:
+		right, ok := b.(BinaryExpr)
+		if !ok {
+			return false
+		}
+		if left.Op != right.Op {
+			return false
+		}
+		return exprEqual(left.Left, right.Left) && exprEqual(left.Right, right.Right)
+	case UnaryExpr:
+		right, ok := b.(UnaryExpr)
+		if !ok {
+			return false
+		}
+		if left.Op != right.Op {
+			return false
+		}
+		return exprEqual(left.Operand, right.Operand)
+	case CallExpr:
+		right, ok := b.(CallExpr)
+		if !ok {
+			return false
+		}
+		if left.Func != right.Func || len(left.Args) != len(right.Args) {
+			return false
+		}
+		for i := range left.Args {
+			if !exprEqual(left.Args[i], right.Args[i]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/minilogic/symbolic.go
+++ b/internal/minilogic/symbolic.go
@@ -7,6 +7,7 @@ type CondSolver interface {
 }
 
 // BasicCondSolver provides simple, sound condition deductions.
+// It is intentionally minimal and may fail to resolve many conditions.
 type BasicCondSolver struct{}
 
 func (BasicCondSolver) Solve(cond Expr, env *Env) (BoolValue, bool) {

--- a/internal/minilogic/types.go
+++ b/internal/minilogic/types.go
@@ -1,0 +1,206 @@
+package minilogic
+
+import "fmt"
+
+// Value represents a symbolic or concrete value in the MiniLogic system.
+// Values can be integers, booleans, strings, nil, or symbolic variables.
+type Value interface {
+	isValue()
+	String() string
+	Equal(other Value) bool
+}
+
+// IntValue represents an integer constant.
+type IntValue struct {
+	Val int64
+}
+
+func (IntValue) isValue() {}
+func (v IntValue) String() string {
+	return fmt.Sprintf("%d", v.Val)
+}
+func (v IntValue) Equal(other Value) bool {
+	if o, ok := other.(IntValue); ok {
+		return v.Val == o.Val
+	}
+	return false
+}
+
+// BoolValue represents a boolean constant.
+type BoolValue struct {
+	Val bool
+}
+
+func (BoolValue) isValue() {}
+func (v BoolValue) String() string {
+	return fmt.Sprintf("%t", v.Val)
+}
+func (v BoolValue) Equal(other Value) bool {
+	if o, ok := other.(BoolValue); ok {
+		return v.Val == o.Val
+	}
+	return false
+}
+
+// StringValue represents a string constant.
+type StringValue struct {
+	Val string
+}
+
+func (StringValue) isValue() {}
+func (v StringValue) String() string {
+	return fmt.Sprintf("%q", v.Val)
+}
+func (v StringValue) Equal(other Value) bool {
+	if o, ok := other.(StringValue); ok {
+		return v.Val == o.Val
+	}
+	return false
+}
+
+// NilValue represents nil.
+type NilValue struct{}
+
+func (NilValue) isValue() {}
+func (NilValue) String() string {
+	return "nil"
+}
+func (v NilValue) Equal(other Value) bool {
+	_, ok := other.(NilValue)
+	return ok
+}
+
+// SymbolicValue represents an unknown symbolic value.
+// Used when we cannot determine the concrete value statically.
+type SymbolicValue struct {
+	Name string
+}
+
+func (SymbolicValue) isValue() {}
+func (v SymbolicValue) String() string {
+	return fmt.Sprintf("<%s>", v.Name)
+}
+func (v SymbolicValue) Equal(other Value) bool {
+	if o, ok := other.(SymbolicValue); ok {
+		return v.Name == o.Name
+	}
+	return false
+}
+
+// Env represents the symbolic environment as a key-value map.
+// It maps variable names to their values.
+type Env struct {
+	vars   map[string]Value
+	parent *Env // for scoped environments (init statements)
+}
+
+// NewEnv creates a new empty environment.
+func NewEnv() *Env {
+	return &Env{
+		vars: make(map[string]Value),
+	}
+}
+
+// NewChildEnv creates a new environment with the given parent.
+// Variables in the child shadow those in the parent.
+func NewChildEnv(parent *Env) *Env {
+	return &Env{
+		vars:   make(map[string]Value),
+		parent: parent,
+	}
+}
+
+// Get retrieves the value of a variable.
+// Returns nil if the variable is not found.
+func (e *Env) Get(name string) Value {
+	if v, ok := e.vars[name]; ok {
+		return v
+	}
+	if e.parent != nil {
+		return e.parent.Get(name)
+	}
+	return nil
+}
+
+// Set sets the value of a variable in the current scope.
+func (e *Env) Set(name string, val Value) {
+	e.vars[name] = val
+}
+
+// Clone creates a deep copy of the environment.
+func (e *Env) Clone() *Env {
+	newEnv := &Env{
+		vars:   make(map[string]Value, len(e.vars)),
+		parent: e.parent, // parent is shared (immutable reference)
+	}
+	for k, v := range e.vars {
+		newEnv.vars[k] = v
+	}
+	return newEnv
+}
+
+// Equal checks if two environments have the same variable bindings.
+func (e *Env) Equal(other *Env) bool {
+	if e == nil && other == nil {
+		return true
+	}
+	if e == nil || other == nil {
+		return false
+	}
+
+	// Get all keys from both environments
+	allKeys := make(map[string]struct{})
+	e.collectKeys(allKeys)
+	other.collectKeys(allKeys)
+
+	for k := range allKeys {
+		v1 := e.Get(k)
+		v2 := other.Get(k)
+		if v1 == nil && v2 == nil {
+			continue
+		}
+		if v1 == nil || v2 == nil {
+			return false
+		}
+		if !v1.Equal(v2) {
+			return false
+		}
+	}
+	return true
+}
+
+func (e *Env) collectKeys(keys map[string]struct{}) {
+	for k := range e.vars {
+		keys[k] = struct{}{}
+	}
+	if e.parent != nil {
+		e.parent.collectKeys(keys)
+	}
+}
+
+// String returns a string representation of the environment.
+func (e *Env) String() string {
+	result := "{"
+	first := true
+	for k, v := range e.vars {
+		if !first {
+			result += ", "
+		}
+		result += fmt.Sprintf("%s: %s", k, v.String())
+		first = false
+	}
+	if e.parent != nil {
+		result += " | parent: " + e.parent.String()
+	}
+	result += "}"
+	return result
+}
+
+// Keys returns all variable names in this environment (not including parent).
+func (e *Env) Keys() []string {
+	keys := make([]string, 0, len(e.vars))
+	for k := range e.vars {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/minilogic/types.go
+++ b/internal/minilogic/types.go
@@ -93,7 +93,7 @@ func (v SymbolicValue) Equal(other Value) bool {
 }
 
 // Env represents the symbolic environment as a key-value map.
-// It maps variable names to their values.
+// It maps variable names to values and does not model heap/aliasing.
 type Env struct {
 	vars   map[string]Value
 	parent *Env // for scoped environments (init statements)

--- a/internal/minilogic/types.go
+++ b/internal/minilogic/types.go
@@ -19,6 +19,7 @@ func (IntValue) isValue() {}
 func (v IntValue) String() string {
 	return fmt.Sprintf("%d", v.Val)
 }
+
 func (v IntValue) Equal(other Value) bool {
 	if o, ok := other.(IntValue); ok {
 		return v.Val == o.Val
@@ -35,6 +36,7 @@ func (BoolValue) isValue() {}
 func (v BoolValue) String() string {
 	return fmt.Sprintf("%t", v.Val)
 }
+
 func (v BoolValue) Equal(other Value) bool {
 	if o, ok := other.(BoolValue); ok {
 		return v.Val == o.Val
@@ -51,6 +53,7 @@ func (StringValue) isValue() {}
 func (v StringValue) String() string {
 	return fmt.Sprintf("%q", v.Val)
 }
+
 func (v StringValue) Equal(other Value) bool {
 	if o, ok := other.(StringValue); ok {
 		return v.Val == o.Val
@@ -65,6 +68,7 @@ func (NilValue) isValue() {}
 func (NilValue) String() string {
 	return "nil"
 }
+
 func (v NilValue) Equal(other Value) bool {
 	_, ok := other.(NilValue)
 	return ok
@@ -80,6 +84,7 @@ func (SymbolicValue) isValue() {}
 func (v SymbolicValue) String() string {
 	return fmt.Sprintf("<%s>", v.Name)
 }
+
 func (v SymbolicValue) Equal(other Value) bool {
 	if o, ok := other.(SymbolicValue); ok {
 		return v.Name == o.Name

--- a/minilogic_poc.md
+++ b/minilogic_poc.md
@@ -1,0 +1,336 @@
+# MiniLogic v2.1
+
+## A Partial Formal Verification Framework for Go Lint Rewrites (Early-Return–Aware)
+
+---
+
+## 0. Revision Summary (v2 → v2.1)
+
+MiniLogic v2.1 revises the v2 specification to better match the behavior of real Go/Gno lint rules, especially **early-return and conditional normalization rules**
+
+Key changes:
+
+1. **Explicit modeling of control-flow termination**
+2. **Restricted support for `return`, `break`, and `continue`**
+3. **Explicit semantics for `if init; cond { … } else { … }`**
+4. **Clear scoping of which lint rules are eligible for verification**
+
+The goal is to avoid returning `Unknown` for the very rewrites that linters actually perform, while still keeping the model intentionally small and sound.
+
+---
+
+## 1. Scope and Supported Lint Rules
+
+### 1.1 Supported by MiniLogic
+
+MiniLogic does **not** attempt to verify all lint rules.
+Only the following classes of rewrites are within scope:
+
+**Supported**
+
+* if–else flattening
+* early-return / early-continue / early-break normalization
+* boolean condition restructuring in control flow
+* merging or splitting conditional returns
+
+**Out of Scope (always `Unknown`)**
+
+* formatting and stylistic rewrites
+* regex-based rewrites
+* type-conversion simplifications
+* reflection or interface-heavy rewrites
+* loop transformations
+* data-flow or performance-oriented optimizations
+
+> **Policy**
+> Rewrites outside the supported set must be reported as `Unknown`.
+> Linters may still emit suggestions, butx must not auto-apply fixes.
+
+---
+
+## 2. Modeled Statement Fragment (Extended)
+
+### 2.1 Statements
+
+The statement language is extended to support early-return validation while remaining deliberately small.
+
+Supported statements:
+
+* Assignment
+
+  ```
+  x = e
+  ```
+
+* Sequencing
+
+  ```
+  S1 ; S2
+  ```
+
+* Conditional
+
+  ```
+  if [init]; cond { S1 } else { S2 }
+  ```
+
+* Termination statements
+
+  ```
+  return e?
+  break
+  continue
+  ```
+
+* Opaque statement (optional)
+
+  ```
+  call(...)
+  ```
+
+Excluded:
+
+* loops (beyond recognizing `break` / `continue`)
+* `defer`
+* goroutines and channels
+* heap mutation or aliasing
+* full CFG or interprocedural analysis
+
+---
+
+## 3. Termination-Aware Semantic Model
+
+### 3.1 Result Type
+
+Statement evaluation produces a **termination-aware result**:
+
+```
+Result =
+  Continue(Env)
+| Return(Value?)
+| Break
+| ContinueLoop
+| ⊥        // undefined / stuck (optional)
+```
+
+This allows equivalence to account for **how execution ends**, not just final environments.
+
+---
+
+### 3.2 Statement Semantics
+
+Let `⟦S⟧ : Env → Result`.
+
+#### Assignment
+
+```
+⟦x = e⟧(σ) = Continue(σ[x ↦ eval(e, σ)])
+```
+
+#### Sequencing (termination-aware)
+
+```
+⟦S1 ; S2⟧(σ) =
+  match ⟦S1⟧(σ) with
+    Continue(σ') → ⟦S2⟧(σ')
+    r            → r
+```
+
+Once a termination result is produced, subsequent statements are not evaluated.
+
+---
+
+#### Conditional with initializer
+
+```
+⟦if init; cond { S1 } else { S2 }⟧(σ) =
+  let σ' = ⟦init⟧(σ) in
+  if eval(cond, σ') == true
+     then ⟦S1⟧(σ')
+     else ⟦S2⟧(σ')
+```
+
+* `init` supports short variable declarations (`:=`) and `var` declarations.
+* Variables introduced by `init` are scoped to the condition and both branches only.
+* If those variables are referenced outside the conditional, the rewrite is invalid and must yield `Unknown`.
+
+---
+
+### 3.3 Termination Statements
+
+```
+⟦return e⟧(σ) = Return(eval(e, σ))
+⟦return⟧(σ)   = Return(nil)
+⟦break⟧(σ)    = Break
+⟦continue⟧(σ) = ContinueLoop
+```
+
+* `break` / `continue` are only well-formed inside loop contexts.
+* If they appear outside a loop, the rewrite is invalid and must yield `Unknown`.
+
+---
+
+### 3.4 Panic and Calls (Policy)
+
+* `panic(...)` is treated as a function call.
+* Function calls are **not modeled semantically**, but call order and multiplicity are tracked under OpaqueCalls.
+
+Two policies are supported:
+
+* **OpaqueCalls (default)**
+  Calls always evaluate to `Continue`.
+  Calls are treated as opaque effects on external state not modeled by `Env`.
+  Equivalence under OpaqueCalls additionally requires preserving call order and multiplicity.
+
+* **DisallowCalls**
+  Any block containing calls is outside the model and yields `Unknown`.
+
+This mirrors the behavior of existing early-return lints, which do not treat `panic` as guaranteed termination.
+
+---
+
+## 4. Observational Equivalence (Termination-Aware)
+
+### 4.1 Statement Equivalence
+
+Two statements `S1` and `S2` are equivalent iff:
+
+```
+∀σ. ⟦S1⟧(σ) = ⟦S2⟧(σ)
+```
+
+Result equality is defined as:
+
+| Result kind  | Equality condition    |
+| ------------ | --------------------- |
+| Continue     | Environments equal    |
+| Return       | Returned values equal |
+| Break        | Both Break            |
+| ContinueLoop | Both ContinueLoop     |
+| Mixed kinds  | Not equivalent        |
+
+---
+
+## 5. Early-Return Rewrite (Normative Rule)
+
+### 5.1 Canonical Patterns
+
+Original:
+
+```go
+if cond {
+    return v
+} else {
+    S
+}
+```
+
+Rewritten:
+
+```go
+if cond {
+    return v
+}
+S
+```
+
+Additional pattern (else-if chain flattening):
+
+```go
+if c1 { return v1 }
+else if c2 { return v2 }
+else { return v3 }
+```
+
+rewritten as:
+
+```go
+if c1 { return v1 }
+if c2 { return v2 }
+return v3
+```
+
+---
+
+### 5.2 Soundness Conditions
+
+The rewrite is valid only if all of the following hold:
+
+1. Under OpaqueCalls, `cond` may contain calls, but the rewrite must not change call order or multiplicity.
+2. Every `if` body in the chain terminates (e.g., `return`, `break`, `continue`).
+3. No `init`-scoped identifiers are referenced outside their `if` statement.
+4. Under OpaqueCalls, the rewrite does not reorder or duplicate calls.
+
+Failure to establish any condition results in `Unknown`.
+
+---
+
+## 6. Function Calls and Side Effects
+
+### 6.1 Default Policy
+
+MiniLogic v2.1 defaults to:
+
+```
+CallPolicy = OpaqueCalls
+```
+
+This allows early-return validation in blocks that contain calls, while preventing unsafe reordering.
+
+---
+
+## 7. SMT and Decision Procedures (Overview)
+
+MiniLogic does not require full CFG encoding.
+
+Two implementation strategies are permitted:
+
+* **Symbolic Result Encoding**
+  Encode termination kind and value explicitly in SMT.
+
+* **Control-Normalization Strategy (recommended for PoC)**
+  Rewrite statements into a single-exit normal form and reduce equivalence to expression equality using `ite`.
+
+Either strategy must be sound with respect to the semantics in Section 3.
+
+---
+
+## 8. Configuration Extensions
+
+Additional configuration flags:
+
+```go
+type ControlFlowMode int
+const (
+  NoTermination
+  EarlyReturnAware
+)
+
+type CallPolicy int
+const (
+  DisallowCalls
+  OpaqueCalls
+)
+```
+
+For early-return validation:
+
+```
+ControlFlowMode = EarlyReturnAware
+CallPolicy      = OpaqueCalls
+```
+
+---
+
+## 9. Revised Non-Goals
+
+MiniLogic v2.1 explicitly does **not** model:
+
+* full loop semantics
+* `defer`
+* panic propagation
+* goroutines or channels
+* heap aliasing or memory models
+* interprocedural control flow
+
+These are unnecessary for validating the targeted lint rules.


### PR DESCRIPTION
## Description

- Introduce the MiniLogic package: a termination-aware, call-order–sensitive verifier for lint rewrite equivalence.
  - Add AST-to-MiniLogic conversion and verification gate so early-return suggestions only apply when verified.
  - Provide normalization utilities, symbolic condition handling, and extensive unit tests covering control-flow, scope, calls, and early-return patterns.

### Key changes

- New internal/minilogic package with evaluator, equivalence checker, normalization, and symbolic condition solver.
  - New internal/lints/minilogic_gate.go with AST conversion and verification for early- return lint.
  - Early-return lint now uses MiniLogic to block unsafe auto-fixes.