### PR TITLE
feat: Add auto-fix with import management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 # Go workspace file
 go.work
 go.work.sum
+
+.gocache

--- a/internal/fixer/fixer_test.go
+++ b/internal/fixer/fixer_test.go
@@ -197,6 +197,8 @@ func example() error {
 			},
 			expected: `package main
 
+import "errors"
+
 func example() error {
 	return errors.New("handler error")
 }

--- a/internal/fixer/fixer_test.go
+++ b/internal/fixer/fixer_test.go
@@ -250,6 +250,62 @@ func main() {
 }
 `,
 		},
+		{
+			name: "Fix - format-without-verb Errorf adds errors import",
+			input: `package main
+
+func example() error {
+	return ufmt.Errorf("handler error")
+}
+`,
+			issues: []tt.Issue{
+				{
+					Rule:            "format-without-verb",
+					Message:         "format string has no verbs; use errors.New() instead",
+					Start:           token.Position{Line: 4, Column: 9},
+					End:             token.Position{Line: 4, Column: 38},
+					Suggestion:      `return errors.New("handler error")`,
+					RequiredImports: []string{"errors"},
+				},
+			},
+			expected: `package main
+
+import "errors"
+
+func example() error {
+	return errors.New("handler error")
+}
+`,
+		},
+		{
+			name: "Fix - does not duplicate existing import",
+			input: `package main
+
+import "errors"
+
+func example() error {
+	return ufmt.Errorf("handler error")
+}
+`,
+			issues: []tt.Issue{
+				{
+					Rule:            "format-without-verb",
+					Message:         "format string has no verbs; use errors.New() instead",
+					Start:           token.Position{Line: 6, Column: 9},
+					End:             token.Position{Line: 6, Column: 38},
+					Suggestion:      `return errors.New("handler error")`,
+					RequiredImports: []string{"errors"},
+				},
+			},
+			expected: `package main
+
+import "errors"
+
+func example() error {
+	return errors.New("handler error")
+}
+`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/fixer/fixer_test.go
+++ b/internal/fixer/fixer_test.go
@@ -178,6 +178,78 @@ func main() {
 }
 `,
 		},
+		{
+			name: "Fix - format-without-verb Errorf with return",
+			input: `package main
+
+func example() error {
+	return ufmt.Errorf("handler error")
+}
+`,
+			issues: []tt.Issue{
+				{
+					Rule:       "format-without-verb",
+					Message:    "format string has no verbs; use errors.New() instead",
+					Start:      token.Position{Line: 4, Column: 9},
+					End:        token.Position{Line: 4, Column: 38},
+					Suggestion: `return errors.New("handler error")`,
+				},
+			},
+			expected: `package main
+
+func example() error {
+	return errors.New("handler error")
+}
+`,
+		},
+		{
+			name: "Fix - format-without-verb Sprintf to literal",
+			input: `package main
+
+func main() {
+	msg := ufmt.Sprintf("hello world")
+}
+`,
+			issues: []tt.Issue{
+				{
+					Rule:       "format-without-verb",
+					Message:    "format string has no verbs; use a string literal directly",
+					Start:      token.Position{Line: 4, Column: 9},
+					End:        token.Position{Line: 4, Column: 37},
+					Suggestion: `msg := "hello world"`,
+				},
+			},
+			expected: `package main
+
+func main() {
+	msg := "hello world"
+}
+`,
+		},
+		{
+			name: "Fix - format-without-verb Printf to print",
+			input: `package main
+
+func main() {
+	ufmt.Printf("status ok")
+}
+`,
+			issues: []tt.Issue{
+				{
+					Rule:       "format-without-verb",
+					Message:    "format string has no verbs; use print() instead",
+					Start:      token.Position{Line: 4, Column: 2},
+					End:        token.Position{Line: 4, Column: 26},
+					Suggestion: `print("status ok")`,
+				},
+			},
+			expected: `package main
+
+func main() {
+	print("status ok")
+}
+`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/fixer/imports.go
+++ b/internal/fixer/imports.go
@@ -1,78 +1,34 @@
 package fixer
 
 import (
-	"bytes"
-	"go/ast"
-	"go/format"
-	"go/parser"
-	"go/token"
+	"path/filepath"
+	"strings"
 
-	tt "github.com/gnolang/tlin/internal/types"
-	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/imports"
 )
 
-// EnsureImports adds missing imports to the source code.
-// It parses the source, checks which imports are missing, adds them,
-// and returns the modified source.
-func EnsureImports(src []byte, imports []string) ([]byte, error) {
-	if len(imports) == 0 {
-		return src, nil
+// ProcessImports uses goimports-style processing to:
+//  1. Add missing imports (for standard library packages)
+//  2. Remove unused imports
+//  3. Format the code
+func ProcessImports(filename string, src []byte) ([]byte, error) {
+	// For .gno files, use .go extension so imports package recognizes it
+	processName := filename
+	if strings.HasSuffix(filename, ".gno") {
+		processName = strings.TrimSuffix(filepath.Base(filename), ".gno") + ".go"
 	}
 
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "", src, parser.ParseComments)
+	opts := &imports.Options{
+		Comments:   true,
+		TabIndent:  true,
+		TabWidth:   8,
+		FormatOnly: false, // Process imports, not just format
+	}
+
+	result, err := imports.Process(processName, src, opts)
 	if err != nil {
 		return src, err
 	}
 
-	modified := false
-	for _, importPath := range imports {
-		if !hasImport(file, importPath) {
-			astutil.AddImport(fset, file, importPath)
-			modified = true
-		}
-	}
-
-	if !modified {
-		return src, nil
-	}
-
-	var buf bytes.Buffer
-	if err := format.Node(&buf, fset, file); err != nil {
-		return src, err
-	}
-
-	return buf.Bytes(), nil
-}
-
-// hasImport checks if the file already has the specified import.
-func hasImport(file *ast.File, importPath string) bool {
-	for _, imp := range file.Imports {
-		// imp.Path.Value includes quotes, e.g., `"errors"`
-		path := imp.Path.Value
-		if len(path) >= 2 {
-			path = path[1 : len(path)-1] // remove quotes
-		}
-		if path == importPath {
-			return true
-		}
-	}
-	return false
-}
-
-// CollectRequiredImports gathers all unique required imports from issues.
-func CollectRequiredImports(issues []tt.Issue) []string {
-	seen := make(map[string]bool)
-	var imports []string
-
-	for _, issue := range issues {
-		for _, imp := range issue.RequiredImports {
-			if !seen[imp] {
-				seen[imp] = true
-				imports = append(imports, imp)
-			}
-		}
-	}
-
-	return imports
+	return result, nil
 }

--- a/internal/fixer/imports.go
+++ b/internal/fixer/imports.go
@@ -1,0 +1,78 @@
+package fixer
+
+import (
+	"bytes"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+
+	tt "github.com/gnolang/tlin/internal/types"
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+// EnsureImports adds missing imports to the source code.
+// It parses the source, checks which imports are missing, adds them,
+// and returns the modified source.
+func EnsureImports(src []byte, imports []string) ([]byte, error) {
+	if len(imports) == 0 {
+		return src, nil
+	}
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "", src, parser.ParseComments)
+	if err != nil {
+		return src, err
+	}
+
+	modified := false
+	for _, importPath := range imports {
+		if !hasImport(file, importPath) {
+			astutil.AddImport(fset, file, importPath)
+			modified = true
+		}
+	}
+
+	if !modified {
+		return src, nil
+	}
+
+	var buf bytes.Buffer
+	if err := format.Node(&buf, fset, file); err != nil {
+		return src, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// hasImport checks if the file already has the specified import.
+func hasImport(file *ast.File, importPath string) bool {
+	for _, imp := range file.Imports {
+		// imp.Path.Value includes quotes, e.g., `"errors"`
+		path := imp.Path.Value
+		if len(path) >= 2 {
+			path = path[1 : len(path)-1] // remove quotes
+		}
+		if path == importPath {
+			return true
+		}
+	}
+	return false
+}
+
+// CollectRequiredImports gathers all unique required imports from issues.
+func CollectRequiredImports(issues []tt.Issue) []string {
+	seen := make(map[string]bool)
+	var imports []string
+
+	for _, issue := range issues {
+		for _, imp := range issue.RequiredImports {
+			if !seen[imp] {
+				seen[imp] = true
+				imports = append(imports, imp)
+			}
+		}
+	}
+
+	return imports
+}

--- a/internal/fixer/imports_test.go
+++ b/internal/fixer/imports_test.go
@@ -1,0 +1,229 @@
+package fixer
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	tt "github.com/gnolang/tlin/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureImports(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		imports  []string
+		expected string
+	}{
+		{
+			name: "add single import to file without imports",
+			src: `package main
+
+func main() {
+	_ = errors.New("test")
+}
+`,
+			imports: []string{"errors"},
+			expected: `package main
+
+import "errors"
+
+func main() {
+	_ = errors.New("test")
+}
+`,
+		},
+		{
+			name: "add import to file with existing imports",
+			src: `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println(errors.New("test"))
+}
+`,
+			imports: []string{"errors"},
+			expected: `package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+func main() {
+	fmt.Println(errors.New("test"))
+}
+`,
+		},
+		{
+			name: "skip already existing import",
+			src: `package main
+
+import "errors"
+
+func main() {
+	_ = errors.New("test")
+}
+`,
+			imports: []string{"errors"},
+			expected: `package main
+
+import "errors"
+
+func main() {
+	_ = errors.New("test")
+}
+`,
+		},
+		{
+			name: "add multiple imports",
+			src: `package main
+
+func main() {
+	io.WriteString(os.Stdout, "test")
+}
+`,
+			imports: []string{"io", "os"},
+			expected: `package main
+
+import (
+	"io"
+	"os"
+)
+
+func main() {
+	io.WriteString(os.Stdout, "test")
+}
+`,
+		},
+		{
+			name: "no imports to add",
+			src: `package main
+
+func main() {
+}
+`,
+			imports:  []string{},
+			expected: `package main
+
+func main() {
+}
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := EnsureImports([]byte(tc.src), tc.imports)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, string(result))
+		})
+	}
+}
+
+func TestHasImport(t *testing.T) {
+	tests := []struct {
+		name       string
+		src        string
+		importPath string
+		expected   bool
+	}{
+		{
+			name: "has import",
+			src: `package main
+
+import "errors"
+
+func main() {}
+`,
+			importPath: "errors",
+			expected:   true,
+		},
+		{
+			name: "does not have import",
+			src: `package main
+
+import "fmt"
+
+func main() {}
+`,
+			importPath: "errors",
+			expected:   false,
+		},
+		{
+			name: "has import in group",
+			src: `package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+func main() {}
+`,
+			importPath: "errors",
+			expected:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fset, file := parseSource(t, tc.src)
+			_ = fset
+			result := hasImport(file, tc.importPath)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestCollectRequiredImports(t *testing.T) {
+	tests := []struct {
+		name     string
+		issues   []tt.Issue
+		expected []string
+	}{
+		{
+			name: "collect from single issue",
+			issues: []tt.Issue{
+				{RequiredImports: []string{"errors"}},
+			},
+			expected: []string{"errors"},
+		},
+		{
+			name: "collect from multiple issues with duplicates",
+			issues: []tt.Issue{
+				{RequiredImports: []string{"errors"}},
+				{RequiredImports: []string{"errors", "fmt"}},
+				{RequiredImports: []string{"io"}},
+			},
+			expected: []string{"errors", "fmt", "io"},
+		},
+		{
+			name: "empty issues",
+			issues: []tt.Issue{
+				{RequiredImports: nil},
+				{RequiredImports: []string{}},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := CollectRequiredImports(tc.issues)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func parseSource(t *testing.T, src string) (*token.FileSet, *ast.File) {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "", src, parser.ParseComments)
+	require.NoError(t, err)
+	return fset, file
+}

--- a/internal/lints/format_without_verb.go
+++ b/internal/lints/format_without_verb.go
@@ -96,14 +96,21 @@ func DetectFormatWithoutVerb(
 		// Build suggestion by replacing the call expression in the original line
 		suggestion := buildLineSuggestion(src, startPos, endPos, funcName, formatVal)
 
+		// Determine required imports based on the replacement
+		var requiredImports []string
+		if funcName == "Errorf" {
+			requiredImports = []string{"errors"}
+		}
+
 		issues = append(issues, tt.Issue{
-			Rule:       "format-without-verb",
-			Filename:   filename,
-			Start:      startPos,
-			End:        endPos,
-			Message:    message,
-			Suggestion: suggestion,
-			Severity:   severity,
+			Rule:            "format-without-verb",
+			Filename:        filename,
+			Start:           startPos,
+			End:             endPos,
+			Message:         message,
+			Suggestion:      suggestion,
+			Severity:        severity,
+			RequiredImports: requiredImports,
 		})
 
 		return true

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -12,15 +12,16 @@ import (
 
 // Issue represents a lint issue found in the code base.
 type Issue struct {
-	Rule       string         `json:"rule"`
-	Category   string         `json:"category"`
-	Filename   string         `json:"filename"`
-	Message    string         `json:"message"`
-	Suggestion string         `json:"suggestion"`
-	Note       string         `json:"note"`
-	Start      token.Position `json:"start"`
-	End        token.Position `json:"end"`
-	Severity   Severity       `json:"severity"`
+	Rule            string         `json:"rule"`
+	Category        string         `json:"category"`
+	Filename        string         `json:"filename"`
+	Message         string         `json:"message"`
+	Suggestion      string         `json:"suggestion"`
+	Note            string         `json:"note"`
+	Start           token.Position `json:"start"`
+	End             token.Position `json:"end"`
+	Severity        Severity       `json:"severity"`
+	RequiredImports []string       `json:"required_imports,omitempty"`
 }
 
 func (i Issue) String() string {
@@ -37,26 +38,28 @@ type PositionWithoutFilename struct {
 }
 
 type IssueWithoutFilename struct {
-	Rule       string                  `json:"rule"`
-	Category   string                  `json:"category"`
-	Message    string                  `json:"message"`
-	Suggestion string                  `json:"suggestion"`
-	Note       string                  `json:"note"`
-	Start      PositionWithoutFilename `json:"start"`
-	End        PositionWithoutFilename `json:"end"`
-	Severity   Severity                `json:"severity"`
+	Rule            string                  `json:"rule"`
+	Category        string                  `json:"category"`
+	Message         string                  `json:"message"`
+	Suggestion      string                  `json:"suggestion"`
+	Note            string                  `json:"note"`
+	Start           PositionWithoutFilename `json:"start"`
+	End             PositionWithoutFilename `json:"end"`
+	Severity        Severity                `json:"severity"`
+	RequiredImports []string                `json:"required_imports,omitempty"`
 }
 
 func (i *Issue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&IssueWithoutFilename{
-		Rule:       i.Rule,
-		Category:   i.Category,
-		Message:    i.Message,
-		Suggestion: i.Suggestion,
-		Note:       i.Note,
-		Start:      PositionWithoutFilename{Offset: i.Start.Offset, Line: i.Start.Line, Column: i.Start.Column},
-		End:        PositionWithoutFilename{Offset: i.End.Offset, Line: i.End.Line, Column: i.End.Column},
-		Severity:   i.Severity,
+		Rule:            i.Rule,
+		Category:        i.Category,
+		Message:         i.Message,
+		Suggestion:      i.Suggestion,
+		Note:            i.Note,
+		Start:           PositionWithoutFilename{Offset: i.Start.Offset, Line: i.Start.Line, Column: i.Start.Column},
+		End:             PositionWithoutFilename{Offset: i.End.Offset, Line: i.End.Line, Column: i.End.Column},
+		Severity:        i.Severity,
+		RequiredImports: i.RequiredImports,
 	})
 }
 


### PR DESCRIPTION
## Description

- enhance `format-with-verb` rule with context-specific suggestions and auto-fix support
- Add automatic import management (add missing, remove unused) after applying fixes
- Add `RequiredImports` field to `Issue` type to track imports needed for fixes

### Import Processing

- Add `ProcessImports` function
- Automatically add required imports (e.g. `errors` package when replacing `ufmt.Errorf`)
- Support `*.gno` files by treating them as `*.go` for import solution