### PR TITLE
fix(formatter): prevent panic when formatting issues with inconsistent indentation

### DIFF
--- a/formatter/builder.go
+++ b/formatter/builder.go
@@ -212,8 +212,18 @@ func underlineAndMessage(message string, padding string, startLine int, endLine 
 	}
 
 	// calculate underline end position
+	// NOTE: when an issue spans multiple lines with inconsistent indentation
+	// (e.g., first line has no indent, subsequent lines are indented),
+	// underlineEnd or underlineLength can become negative, causing panic
+	// in strings.Repeat. We clamp these values to ensure valid output.
 	underlineEnd := calculateVisualColumn(snippetLines[endLine-1], endColumn) - commonIndentWidth
+	if underlineEnd < 0 {
+		underlineEnd = 0
+	}
 	underlineLength := underlineEnd - underlineStart + 1
+	if underlineLength < 1 {
+		underlineLength = 1
+	}
 
 	endString += fmt.Sprint(strings.Repeat(" ", underlineStart))
 	endString += messageStyle.Sprintf("%s\n", strings.Repeat("^", underlineLength))


### PR DESCRIPTION
## Description

- Fix `strings: negative Repeat count` panic in `underlineAndMessage` when formatting issues that span multiple lines with inconsistent indentation
- Add bound checking for `underlineEnd`/`underlineLength` to ensure they are non-negative

## Problem
When linting code where the first line has no indentation but subsequent lines are indented:
```go
_, ok := result.(IType)
      if !ok {
          return errors.New("...")
      } else {
          // ...
      }
```

The formatter would panic because commonIndent was calculated as empty (due to the first line), causing underlineLength to become negative when formatting multi-line issues.