### PR TITLE
fix(emit-format): handle chained method call in `formatCallExpr`

### DIFF
--- a/internal/lints/format_emit.go
+++ b/internal/lints/format_emit.go
@@ -117,7 +117,7 @@ func formatArg(arg ast.Expr) string {
 func formatCallExpr(call *ast.CallExpr) string {
 	var sb strings.Builder
 	if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
-		sb.WriteString(sel.X.(*ast.Ident).Name)
+		sb.WriteString(formatEmitExpr(sel.X))
 		sb.WriteString(".")
 		sb.WriteString(sel.Sel.Name)
 	} else if ident, ok := call.Fun.(*ast.Ident); ok {
@@ -132,4 +132,17 @@ func formatCallExpr(call *ast.CallExpr) string {
 	}
 	sb.WriteString(")")
 	return sb.String()
+}
+
+func formatEmitExpr(expr ast.Expr) string {
+	switch v := expr.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.CallExpr:
+		return formatCallExpr(v)
+	case *ast.SelectorExpr:
+		return formatEmitExpr(v.X) + "." + v.Sel.Name
+	default:
+		return "..."
+	}
 }

--- a/internal/lints/lint_test.go
+++ b/internal/lints/lint_test.go
@@ -322,6 +322,17 @@ func TestFormatEmitCall(t *testing.T) {
     "amount", token.Format(amount),
 )`,
 		},
+		{
+			name:  "Emit call with chained method calls",
+			input: `chain.Emit("UpdateConfig", "callerAddr", ctx.Caller().String(), "callerPath", ctx.Path(), "newVal", conv.FormatInt(newVal, 10), "prevVal", conv.FormatInt(prevVal, 10))`,
+			expected: `chain.Emit(
+    "UpdateConfig",
+    "callerAddr", ctx.Caller().String(),
+    "callerPath", ctx.Path(),
+    "newVal", conv.FormatInt(newVal, 10),
+    "prevVal", conv.FormatInt(prevVal, 10),
+)`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
  - Fix panic when processing chained method calls (e.g., `ctx.Caller().String()`) in emit format rule
  - Add `formatEmitExpr` helper to safely handle various `ast.Expr` types

## Problem

The `formatCallExpr` function assumed `SelectorExpr.X` is always `*ast.Ident`, causing a panic when encountering chained method calls like `obj.Method().AnotherMethod()` where `X` is `*ast.CallExpr`.

## Changes

- Replace unsafe type assertion with `formatEmitExpr` helper that handles `*ast.Ident`, `*ast.CallExpr`, and `*ast.SelectorExpr`
- Add test case for chained method calls