### PR TITLE
fix(unused-package): handle versioned gno import paths

### DIFF
--- a/internal/lints/gno_analyzer.go
+++ b/internal/lints/gno_analyzer.go
@@ -6,11 +6,17 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/gnolang/tlin/internal/rule"
 	tt "github.com/gnolang/tlin/internal/types"
 )
+
+// versionSuffix matches a trailing path segment of the form v0, v1, …
+// gno import paths use this convention (see gnolang/gno#5220), so the
+// real package name is the segment preceding it, not "vN".
+var versionSuffix = regexp.MustCompile(`^v\d+$`)
 
 func init() {
 	rule.Register(unusedPackageRule{})
@@ -87,7 +93,7 @@ func extractDependencies(file *ast.File) Dependencies {
 				for _, imp := range file.Imports {
 					if imp.Name != nil && imp.Name.Name == ident.Name {
 						deps[strings.Trim(imp.Path.Value, `"`)].IsUsed = true
-					} else if lastPart := getLastPart(strings.Trim(imp.Path.Value, `"`)); lastPart == ident.Name {
+					} else if pkgName := effectivePackageName(strings.Trim(imp.Path.Value, `"`)); pkgName == ident.Name {
 						deps[strings.Trim(imp.Path.Value, `"`)].IsUsed = true
 					}
 				}
@@ -116,7 +122,10 @@ func isGnoPackage(importPath string) bool {
 	return strings.HasPrefix(importPath, GNO_PKG_PREFIX) || importPath == GNO_STD_PACKAGE
 }
 
-func getLastPart(path string) string {
+func effectivePackageName(path string) string {
 	parts := strings.Split(path, "/")
+	if len(parts) >= 2 && versionSuffix.MatchString(parts[len(parts)-1]) {
+		return parts[len(parts)-2]
+	}
 	return parts[len(parts)-1]
 }

--- a/internal/lints/gno_analyzer_test.go
+++ b/internal/lints/gno_analyzer_test.go
@@ -65,6 +65,20 @@ func TestRunLinter(t *testing.T) {
 				"strings": {false, true, false},
 			},
 		},
+		{
+			filename: filepath.Join(testDir, "pkg2.gno"),
+			expectedIssues: []struct {
+				rule    string
+				message string
+			}{},
+			expectedDeps: map[string]struct {
+				isGno     bool
+				isUsed    bool
+				isIgnored bool
+			}{
+				"gno.land/p/nt/ufmt/v0": {true, true, false},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/testdata/pkg/pkg2.gno
+++ b/testdata/pkg/pkg2.gno
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"gno.land/p/nt/ufmt/v0"
+)
+
+func main() {
+	ufmt.Sprintf("hello %s", "world")
+}


### PR DESCRIPTION
## Summary

- Fix a false-positive in the `unused-package` rule for gno import paths that carry a trailing version segment such as `gno.land/p/nt/ufmt/v0`.
- `extractDependencies` derived the package identifier from the last path segment, so it became `v0` and never matched the real `ufmt.X` selector in source. This started happening after gnolang/gno#5220 added the version suffix convention.
- Replace `getLastPart` with `effectivePackageName`, which strips a trailing `^v\d+$` segment and falls back to the preceding segment as the conventional package name.

## Repro

The gnoswap CI ([example run](https://github.com/gnoswap-labs/gnoswap/actions/runs/24982317573/job/73147207606)) reports `unused import: gno.land/p/nt/ufmt/v0` at `contract/r/gnoswap/test/fuzz/_mock_test.gno:9:2`, even though the import is used as `ufmt.X` in the file.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/lints/` passes
- [x] Added `testdata/pkg/pkg2.gno` regression case: imports `gno.land/p/nt/ufmt/v0`, calls `ufmt.Sprintf`, asserts no `unused-package` issue is produced
- [ ] Re-run tlin against the gnoswap repo and confirm the false-positive is gone